### PR TITLE
Refactor scripts to follow SOLID modules

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "description": "Enhance your online apparel shopping experience with Imagine.",
   "permissions": ["sidePanel", "storage", "tabs", "activeTab", "scripting"],
   "background": {
-    "service_worker": "src/background/background.js"
+    "service_worker": "src/background/background.js",
+    "type": "module"
   },
   "action": {
     "default_title": "Open side panel"

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,3 +1,5 @@
+import { isOnlineStore } from "./modules/urlUtils.js";
+
 chrome.runtime.onInstalled.addListener(() => {
   if (chrome.sidePanel && chrome.sidePanel.setPanelBehavior) {
     chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
@@ -17,23 +19,17 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.tabs.onCreated.addListener((tab) => {
   chrome.scripting.executeScript({
     target: { tabId: tab.id },
-    function: checkAndOpenTab,
+    func: checkAndOpenTab,
   });
 });
 
 function checkAndOpenTab() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const url = new URL(tabs[0].url);
-    const isStore = isOnlineStore(url);
-    if (isStore) {
+    if (isOnlineStore(url)) {
       document.getElementById("home-tab").click();
     } else {
       document.getElementById("store-discovery-tab").click();
     }
   });
-
-  function isOnlineStore(url) {
-    const onlineStoreDomains = ["example-store.com", "another-store.com"];
-    return onlineStoreDomains.some((domain) => url.hostname.includes(domain));
-  }
 }

--- a/src/background/modules/urlUtils.js
+++ b/src/background/modules/urlUtils.js
@@ -1,0 +1,4 @@
+export function isOnlineStore(url) {
+  const onlineStoreDomains = ["example-store.com", "another-store.com"];
+  return onlineStoreDomains.some((domain) => url.hostname.includes(domain));
+}

--- a/src/popup/modules/debounce.js
+++ b/src/popup/modules/debounce.js
@@ -1,0 +1,7 @@
+export function debounce(func, delay) {
+  let timeout;
+  return function (...args) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(this, args), delay);
+  };
+}

--- a/src/popup/modules/storeService.js
+++ b/src/popup/modules/storeService.js
@@ -1,0 +1,24 @@
+export async function loadStores(dataUrl) {
+  const response = await fetch(chrome.runtime.getURL(dataUrl));
+  return response.json();
+}
+
+export function applyFilters(stores, filters, searchTerm = "") {
+  const term = searchTerm.toLowerCase();
+  return stores.filter((store) => {
+    const matchesSearch =
+      term === "" ||
+      store.name.toLowerCase().includes(term) ||
+      store.clothingType.toLowerCase().includes(term);
+    const matchesDemographic =
+      filters.targetDemographic.length === 0 ||
+      filters.targetDemographic.some((demo) => store.targetDemographic.includes(demo));
+    const matchesClothing =
+      filters.clothingType.length === 0 ||
+      filters.clothingType.includes(store.clothingType);
+    const matchesPrice =
+      filters.priceRange.length === 0 ||
+      filters.priceRange.includes(store.priceRange);
+    return matchesSearch && matchesDemographic && matchesClothing && matchesPrice;
+  });
+}

--- a/src/popup/modules/ui.js
+++ b/src/popup/modules/ui.js
@@ -1,0 +1,39 @@
+export function renderStores(container, stores, displayed) {
+  container.innerHTML = "";
+  const visible = stores.slice(0, displayed);
+  visible.forEach((store) => {
+    const item = document.createElement("div");
+    item.className = "store-item";
+    const imageUrl = chrome.runtime.getURL(store.image);
+    item.innerHTML = `<img src="${imageUrl}" alt="${store.name}" />\n        <p>${store.name}</p>`;
+    item.addEventListener("click", () => {
+      chrome.tabs.create({ url: store.url });
+    });
+    container.appendChild(item);
+  });
+}
+
+export function updateLoadMoreButton(button, displayed, total) {
+  button.style.display = displayed >= total ? "none" : "block";
+}
+
+export function generateCheckboxes(name, options, selected) {
+  return options
+    .map(
+      (opt) => `
+        <label>
+          <input type="checkbox" name="${name}" value="${opt}" ${
+        selected.includes(opt) ? "checked" : ""
+      }>
+          ${opt}
+        </label>
+      `
+    )
+    .join("");
+}
+
+export function getCheckedValues(name) {
+  return Array.from(document.querySelectorAll(`input[name="${name}"]:checked`)).map(
+    (input) => input.value
+  );
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -417,6 +417,6 @@
       </div>
     </div>
 
-    <script src="popup.js"></script>
+    <script type="module" src="popup.js"></script>
   </body>
 </html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,169 +1,99 @@
-document.addEventListener("DOMContentLoaded", () => {
+import { loadStores, applyFilters } from './modules/storeService.js';
+import { renderStores, updateLoadMoreButton, generateCheckboxes, getCheckedValues } from './modules/ui.js';
+import { debounce } from './modules/debounce.js';
+
+document.addEventListener('DOMContentLoaded', () => {
   initializeApp();
-  initializeTabSwitching(); // Initialize tab switching AFTER all tabs have been initialized
+  initializeTabSwitching();
 });
 
 function initializeTabSwitching() {
-  // Get tab buttons and content containers
-  const tabButtons = document.querySelectorAll(".tab-button");
-  const tabContents = document.querySelectorAll(".tab-content");
+  const tabButtons = document.querySelectorAll('.tab-button');
+  const tabContents = document.querySelectorAll('.tab-content');
 
-  // Function to handle tab switching
-  function switchTab(clickedTab) {
-    // Remove 'active' class from all buttons and contents
-    tabButtons.forEach((button) => button.classList.remove("active"));
-    tabContents.forEach((content) => content.classList.remove("active"));
+  const switchTab = (clickedTab) => {
+    tabButtons.forEach((button) => button.classList.remove('active'));
+    tabContents.forEach((content) => content.classList.remove('active'));
 
-    // Add 'active' class to the clicked tab and corresponding content
-    clickedTab.classList.add("active");
-    const targetContentId = clickedTab.id.replace("-tab", "");
-    document.getElementById(targetContentId).classList.add("active");
-  }
-
-  // Add click event listeners to all tabs
-  tabButtons.forEach((button) => {
-    button.addEventListener("click", () => {
-      switchTab(button);
-    });
-  });
-
-  // Set the default active tab (Store Discovery)
-  document.getElementById("store-discovery-tab").click();
-}
-
-function initializeApp() {
-  const storeGrid = document.getElementById("store-grid");
-  const loadMoreButton = document.getElementById("load-more");
-  const searchBar = document.getElementById("search-bar");
-  const filterButton = document.getElementById("filter-button");
-  const filterSection = document.getElementById("filter-section");
-
-  let stores = [];
-  let filteredStores = [];
-  let displayedStores = 8; // Default number of stores to display
-  let filters = {
-    targetDemographic: [],
-    clothingType: [],
-    priceRange: [],
+    clickedTab.classList.add('active');
+    const targetContentId = clickedTab.id.replace('-tab', '');
+    document.getElementById(targetContentId).classList.add('active');
   };
 
-  loadStores();
+  tabButtons.forEach((button) => {
+    button.addEventListener('click', () => switchTab(button));
+  });
+
+  document.getElementById('store-discovery-tab').click();
+}
+
+async function initializeApp() {
+  const storeGrid = document.getElementById('store-grid');
+  const loadMoreButton = document.getElementById('load-more');
+  const searchBar = document.getElementById('search-bar');
+  const filterButton = document.getElementById('filter-button');
+  const filterSection = document.getElementById('filter-section');
+
+  let stores = await loadStores('src/assets/data/stores.json');
+  let filters = { targetDemographic: [], clothingType: [], priceRange: [] };
+  let displayedStores = 8;
+  let filteredStores = stores;
+
+  renderStores(storeGrid, filteredStores, displayedStores);
+  updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
   initializeEventListeners();
-
-  function loadStores() {
-    fetch(chrome.runtime.getURL("src/assets/data/stores.json"))
-      .then((response) => response.json())
-      .then((data) => {
-        stores = data;
-        filteredStores = stores;
-        renderStores();
-      });
-  }
-
-  function renderStores(clear = true) {
-    if (clear) storeGrid.innerHTML = "";
-
-    const visibleStores = filteredStores.slice(0, displayedStores);
-    visibleStores.forEach((store) => {
-      const storeItem = document.createElement("div");
-      storeItem.className = "store-item";
-      const imageUrl = chrome.runtime.getURL(store.image);
-
-      storeItem.innerHTML = `
-        <img src="${imageUrl}" alt="${store.name}" />
-        <p>${store.name}</p>
-      `;
-      storeItem.addEventListener("click", () => {
-        chrome.tabs.create({ url: store.url });
-      });
-      storeGrid.appendChild(storeItem);
-    });
-
-    updateLoadMoreButton();
-  }
-
-  function updateLoadMoreButton() {
-    if (displayedStores >= filteredStores.length) {
-      loadMoreButton.style.display = "none";
-    } else {
-      loadMoreButton.style.display = "block";
-    }
-  }
 
   function initializeEventListeners() {
     searchBar.addEventListener(
-      "input",
+      'input',
       debounce(() => {
-        const searchTerm = searchBar.value.toLowerCase();
-        if (searchTerm === "") {
-          resetFiltersAndSearch();
-        } else {
-          filteredStores = stores.filter(
-            (store) =>
-              store.name.toLowerCase().includes(searchTerm) ||
-              store.clothingType.toLowerCase().includes(searchTerm)
-          );
-          displayedStores = 8; // Reset displayed stores
-          renderStores();
-        }
+        filteredStores = applyFilters(stores, filters, searchBar.value);
+        displayedStores = 8;
+        renderStores(storeGrid, filteredStores, displayedStores);
+        updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
       }, 300)
     );
 
-    loadMoreButton.addEventListener("click", () => {
+    loadMoreButton.addEventListener('click', () => {
       displayedStores += 8;
-      renderStores(false); // Render additional stores without clearing the grid
+      renderStores(storeGrid, filteredStores, displayedStores);
+      updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
     });
 
-    filterButton.addEventListener("click", () => {
-      filterSection.style.display =
-        filterSection.style.display === "none" ? "block" : "none";
-      if (filterSection.style.display === "block") {
+    filterButton.addEventListener('click', () => {
+      filterSection.style.display = filterSection.style.display === 'none' ? 'block' : 'none';
+      if (filterSection.style.display === 'block') {
         renderFilterOptions();
       }
     });
 
-    // Personalized Avatar Section Handling
-    const avatarSwatch = document.querySelector(".avatar-swatch");
-    const avatarSection = document.querySelector(".avatar-section");
-
-    avatarSwatch.addEventListener("click", () => {
-      avatarSection.style.display =
-        avatarSection.style.display === "none" ? "block" : "none";
-    });
-  }
-
-  function resetFiltersAndSearch() {
-    filteredStores = stores;
-    displayedStores = 8;
-    renderStores();
-  }
-
-  function debounce(func, delay) {
-    let timeout;
-    return function (...args) {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => func.apply(this, args), delay);
-    };
+    const avatarSwatch = document.querySelector('.avatar-swatch');
+    const avatarSection = document.querySelector('.avatar-section');
+    if (avatarSwatch && avatarSection) {
+      avatarSwatch.addEventListener('click', () => {
+        avatarSection.style.display = avatarSection.style.display === 'none' ? 'block' : 'none';
+      });
+    }
   }
 
   function renderFilterOptions() {
     filterSection.innerHTML = `
       <h3>Target Demographic</h3>
       ${generateCheckboxes(
-        "targetDemographic",
-        [...new Set(stores.flatMap((store) => store.targetDemographic))],
+        'targetDemographic',
+        [...new Set(stores.flatMap((s) => s.targetDemographic))],
         filters.targetDemographic
       )}
       <h3>Clothing Type</h3>
       ${generateCheckboxes(
-        "clothingType",
-        [...new Set(stores.map((store) => store.clothingType))],
+        'clothingType',
+        [...new Set(stores.map((s) => s.clothingType))],
         filters.clothingType
       )}
       <h3>Price Range</h3>
       ${generateCheckboxes(
-        "priceRange",
-        [...new Set(stores.map((store) => store.priceRange))],
+        'priceRange',
+        [...new Set(stores.map((s) => s.priceRange))],
         filters.priceRange
       )}
       <div class="filter-buttons">
@@ -173,80 +103,31 @@ function initializeApp() {
       </div>
     `;
 
-    document.getElementById("apply-filters").addEventListener("click", () => {
-      applyFilters();
-      filterSection.style.display = "none";
+    document.getElementById('apply-filters').addEventListener('click', () => {
+      filters = {
+        targetDemographic: getCheckedValues('targetDemographic'),
+        clothingType: getCheckedValues('clothingType'),
+        priceRange: getCheckedValues('priceRange'),
+      };
+      filteredStores = applyFilters(stores, filters, searchBar.value);
+      displayedStores = 8;
+      renderStores(storeGrid, filteredStores, displayedStores);
+      updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
+      filterSection.style.display = 'none';
     });
 
-    document.getElementById("clear-filters").addEventListener("click", () => {
-      clearFilters();
-      renderStores();
-      filterSection.style.display = "none";
+    document.getElementById('clear-filters').addEventListener('click', () => {
+      filters = { targetDemographic: [], clothingType: [], priceRange: [] };
+      filteredStores = applyFilters(stores, filters, searchBar.value);
+      displayedStores = 8;
+      renderStores(storeGrid, filteredStores, displayedStores);
+      updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
+      filterSection.style.display = 'none';
     });
 
-    document.getElementById("close-filters").addEventListener("click", () => {
-      filterSection.style.display = "none";
+    document.getElementById('close-filters').addEventListener('click', () => {
+      filterSection.style.display = 'none';
     });
-  }
-
-  function generateCheckboxes(filterName, options, selectedOptions) {
-    return options
-      .map(
-        (option) => `
-          <label>
-            <input type="checkbox" name="${filterName}" value="${option}" ${
-          selectedOptions.includes(option) ? "checked" : ""
-        }>
-            ${option}
-          </label>
-        `
-      )
-      .join("");
-  }
-
-  function applyFilters() {
-    const selectedFilters = {
-      targetDemographic: getCheckedValues("targetDemographic"),
-      clothingType: getCheckedValues("clothingType"),
-      priceRange: getCheckedValues("priceRange"),
-    };
-
-    filters = selectedFilters;
-
-    filteredStores = stores.filter((store) => {
-      const matchesDemographic =
-        selectedFilters.targetDemographic.length === 0 ||
-        selectedFilters.targetDemographic.some((demo) =>
-          store.targetDemographic.includes(demo)
-        );
-      const matchesClothing =
-        selectedFilters.clothingType.length === 0 ||
-        selectedFilters.clothingType.includes(store.clothingType);
-      const matchesPrice =
-        selectedFilters.priceRange.length === 0 ||
-        selectedFilters.priceRange.includes(store.priceRange);
-
-      return matchesDemographic && matchesClothing && matchesPrice;
-    });
-
-    displayedStores = 8;
-    renderStores();
-  }
-
-  function getCheckedValues(name) {
-    return Array.from(
-      document.querySelectorAll(`input[name="${name}"]:checked`)
-    ).map((input) => input.value);
-  }
-
-  function clearFilters() {
-    filters = {
-      targetDemographic: [],
-      clothingType: [],
-      priceRange: [],
-    };
-    searchBar.value = ""; // Clear the search bar
-    filteredStores = stores;
-    displayedStores = 8;
   }
 }
+


### PR DESCRIPTION
## Summary
- modularize background script and add URL utils
- split popup logic into modules for data, UI and utilities
- switch popup and background to ES modules

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858f5e87280832f91ce730f67156629