### PR TITLE
Refactor tab checks into service worker

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -16,20 +16,11 @@ chrome.runtime.onInstalled.addListener(() => {
   }
 });
 
-chrome.tabs.onCreated.addListener((tab) => {
-  chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    func: checkAndOpenTab,
+chrome.tabs.onCreated.addListener(() => {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (!tabs || !tabs.length || !tabs[0].url) return;
+    const url = new URL(tabs[0].url);
+    const target = isOnlineStore(url) ? "home-tab" : "store-discovery-tab";
+    chrome.runtime.sendMessage({ action: "selectTab", target });
   });
 });
-
-function checkAndOpenTab() {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    const url = new URL(tabs[0].url);
-    if (isOnlineStore(url)) {
-      document.getElementById("home-tab").click();
-    } else {
-      document.getElementById("store-discovery-tab").click();
-    }
-  });
-}

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -5,6 +5,12 @@ import { debounce } from './modules/debounce.js';
 document.addEventListener('DOMContentLoaded', () => {
   initializeApp();
   initializeTabSwitching();
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.action === 'selectTab') {
+      const button = document.getElementById(message.target);
+      if (button) button.click();
+    }
+  });
 });
 
 function initializeTabSwitching() {


### PR DESCRIPTION
## Summary
- remove inline chrome.tabs usage from injected script
- have service worker query the active tab and send UI update messages
- listen for messages in popup to switch tabs accordingly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858ff27fda0832f903e331d870c10af