### PR TITLE
Improve options save error handling

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,6 +1,10 @@
 document.getElementById("save-settings").addEventListener("click", () => {
   const theme = document.getElementById("theme").value;
   chrome.storage.sync.set({ theme: theme }, () => {
-    alert("Settings saved!");
+    if (chrome.runtime.lastError) {
+      alert("Failed to save settings. Please try again.");
+    } else {
+      alert("Settings saved!");
+    }
   });
 });


### PR DESCRIPTION
## Summary
- handle errors from `chrome.storage.sync.set` in options page
- show a helpful alert message when saving fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859026b8484832f83acd2be3a1c3e9f