### PR TITLE
Improve store data fetching error handling

### DIFF
--- a/src/popup/modules/storeService.js
+++ b/src/popup/modules/storeService.js
@@ -1,6 +1,14 @@
 export async function loadStores(dataUrl) {
-  const response = await fetch(chrome.runtime.getURL(dataUrl));
-  return response.json();
+  try {
+    const response = await fetch(chrome.runtime.getURL(dataUrl));
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${dataUrl}: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error loading stores:', error);
+    throw error;
+  }
 }
 
 export function applyFilters(stores, filters, searchTerm = "") {


### PR DESCRIPTION
## Summary
- add robust error handling when loading store data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859025cc888832f82ec3283c10420e0