### PR TITLE
Add settings button to popup

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -30,13 +30,16 @@
         <button class="tab-button" id="dressing-room-tab">
           <i class="fas fa-tshirt"></i>
         </button>
-        <button class="tab-button" id="wishlist-tab">
-          <i class="fas fa-heart"></i>
-        </button>
-        <button class="tab-button" id="home-tab">
-          <i class="fas fa-home"></i>
-        </button>
-      </div>
+          <button class="tab-button" id="wishlist-tab">
+            <i class="fas fa-heart"></i>
+          </button>
+          <button class="tab-button" id="home-tab">
+            <i class="fas fa-home"></i>
+          </button>
+          <button class="tab-button" id="options-button">
+            <i class="fas fa-cog"></i>
+          </button>
+        </div>
 
       <div id="tab-content">
         <!-- Store Discovery Tab Content -->

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -14,7 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function initializeTabSwitching() {
-  const tabButtons = document.querySelectorAll('.tab-button');
+  const tabButtons = document.querySelectorAll('.tab-button:not(#options-button)');
+  const optionsButton = document.getElementById('options-button');
   const tabContents = document.querySelectorAll('.tab-content');
 
   const switchTab = (clickedTab) => {
@@ -29,6 +30,14 @@ function initializeTabSwitching() {
   tabButtons.forEach((button) => {
     button.addEventListener('click', () => switchTab(button));
   });
+
+  if (optionsButton) {
+    optionsButton.addEventListener('click', () => {
+      if (chrome.runtime && chrome.runtime.openOptionsPage) {
+        chrome.runtime.openOptionsPage();
+      }
+    });
+  }
 
   document.getElementById('store-discovery-tab').click();
 }

--- a/src/popup/styles/tabs.css
+++ b/src/popup/styles/tabs.css
@@ -59,3 +59,9 @@
 .tab-button.active i {
   color: white; /* White icon for active tab */
 }
+
+/* Settings (gear) button should align with other tabs */
+#options-button {
+  width: 50px;
+  height: 50px;
+}


### PR DESCRIPTION
## Summary
- add a new Options button with a gear icon in the tab bar
- open the extension options page when the button is clicked
- style the options button so it matches the other tabs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685908ce376c832fb1755f569063151b