### PR TITLE
Handle store load failures gracefully

### DIFF
--- a/src/popup/modules/storeService.js
+++ b/src/popup/modules/storeService.js
@@ -7,7 +7,11 @@ export async function loadStores(dataUrl) {
     return await response.json();
   } catch (error) {
     console.error('Error loading stores:', error);
-    throw error;
+    if (error instanceof TypeError) {
+      // Network or fetch failure, return an empty array so the UI can handle it
+      return [];
+    }
+    throw new Error(`Failed to load stores: ${error.message}`);
   }
 }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -40,7 +40,14 @@ async function initializeApp() {
   const filterButton = document.getElementById('filter-button');
   const filterSection = document.getElementById('filter-section');
 
-  let stores = await loadStores('src/assets/data/stores.json');
+  let stores = [];
+  try {
+    stores = await loadStores('src/assets/data/stores.json');
+  } catch (error) {
+    console.error(error);
+    storeGrid.innerHTML = '<p>Unable to load stores. Please try again later.</p>';
+    return;
+  }
   let filters = { targetDemographic: [], clothingType: [], priceRange: [] };
   let displayedStores = 8;
   let filteredStores = stores;


### PR DESCRIPTION
## Summary
- guard store loading against network failures
- propagate detailed loading error message in `loadStores`
- show a helpful message if stores can't be loaded

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685908b4be28832fbaabb8076478f72f