### PR TITLE
Load and cache store domains

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,4 +1,7 @@
-import { isOnlineStore } from "./modules/urlUtils.js";
+import { isOnlineStore, loadStoreDomains } from "./modules/urlUtils.js";
+
+// Warm up the domain cache when the service worker starts
+loadStoreDomains();
 
 chrome.runtime.onInstalled.addListener(() => {
   if (chrome.sidePanel && chrome.sidePanel.setPanelBehavior) {
@@ -17,10 +20,12 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 chrome.tabs.onCreated.addListener(() => {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+  chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
     if (!tabs || !tabs.length || !tabs[0].url) return;
     const url = new URL(tabs[0].url);
-    const target = isOnlineStore(url) ? "home-tab" : "store-discovery-tab";
+    const target = (await isOnlineStore(url))
+      ? "home-tab"
+      : "store-discovery-tab";
     chrome.runtime.sendMessage({ action: "selectTab", target });
   });
 });

--- a/src/background/modules/urlUtils.js
+++ b/src/background/modules/urlUtils.js
@@ -1,4 +1,25 @@
-export function isOnlineStore(url) {
-  const onlineStoreDomains = ["example-store.com", "another-store.com"];
-  return onlineStoreDomains.some((domain) => url.hostname.includes(domain));
+const STORES_DATA_PATH = "src/assets/data/stores.json";
+let cachedDomains = null;
+
+export async function loadStoreDomains() {
+  if (cachedDomains) {
+    return cachedDomains;
+  }
+  try {
+    const response = await fetch(chrome.runtime.getURL(STORES_DATA_PATH));
+    const stores = await response.json();
+    cachedDomains = stores.map((store) =>
+      new URL(store.url).hostname.replace(/^www\./, "")
+    );
+  } catch (error) {
+    console.error("Failed to load store domains", error);
+    cachedDomains = [];
+  }
+  return cachedDomains;
+}
+
+export async function isOnlineStore(url) {
+  const onlineStoreDomains = await loadStoreDomains();
+  const host = url.hostname.replace(/^www\./, "");
+  return onlineStoreDomains.some((domain) => host.includes(domain));
 }


### PR DESCRIPTION
## Summary
- load store domains from `stores.json`
- cache the domain list at runtime
- update `isOnlineStore` and background script to use cached list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685908ae121c832f9da5dce609b10185