### PR TITLE
Add arrow scrolling for model swatches

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -80,6 +80,34 @@ async function initializeApp() {
         avatarSection.style.display = avatarSection.style.display === 'none' ? 'block' : 'none';
       });
     }
+
+    const modelGrid = document.querySelector('.model-swatch-grid');
+    const leftBtn = document.querySelector('.left-btn');
+    const rightBtn = document.querySelector('.right-btn');
+
+    if (modelGrid) {
+      const updateButtons = () => {
+        if (leftBtn) leftBtn.disabled = modelGrid.scrollLeft <= 0;
+        if (rightBtn)
+          rightBtn.disabled =
+            modelGrid.scrollLeft + modelGrid.clientWidth >= modelGrid.scrollWidth;
+      };
+
+      if (leftBtn) {
+        leftBtn.addEventListener('click', () => {
+          modelGrid.scrollBy({ left: -100, behavior: 'smooth' });
+        });
+      }
+
+      if (rightBtn) {
+        rightBtn.addEventListener('click', () => {
+          modelGrid.scrollBy({ left: 100, behavior: 'smooth' });
+        });
+      }
+
+      modelGrid.addEventListener('scroll', updateButtons);
+      updateButtons();
+    }
   }
 
   function renderFilterOptions() {


### PR DESCRIPTION
## Summary
- add JS logic to scroll the model swatch grid on arrow clicks
- disable arrows when grid cannot scroll further

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685908a54028832fac8548588dfcf922