### PR TITLE
Add theme loading support

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,10 +1,21 @@
-document.getElementById("save-settings").addEventListener("click", () => {
-  const theme = document.getElementById("theme").value;
-  chrome.storage.sync.set({ theme: theme }, () => {
-    if (chrome.runtime.lastError) {
-      alert("Failed to save settings. Please try again.");
-    } else {
-      alert("Settings saved!");
+document.addEventListener('DOMContentLoaded', () => {
+  const themeSelect = document.getElementById('theme');
+  chrome.storage.sync.get('theme', ({ theme }) => {
+    if (theme) {
+      themeSelect.value = theme;
     }
   });
+
+  document
+    .getElementById('save-settings')
+    .addEventListener('click', () => {
+      const theme = themeSelect.value;
+      chrome.storage.sync.set({ theme: theme }, () => {
+        if (chrome.runtime.lastError) {
+          alert('Failed to save settings. Please try again.');
+        } else {
+          alert('Settings saved!');
+        }
+      });
+    });
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -3,6 +3,11 @@ import { renderStores, updateLoadMoreButton, generateCheckboxes, getCheckedValue
 import { debounce } from './modules/debounce.js';
 
 document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.sync.get('theme', ({ theme }) => {
+    document.body.classList.remove('theme-dark', 'theme-light');
+    document.body.classList.add(theme === 'dark' ? 'theme-dark' : 'theme-light');
+  });
+
   initializeApp();
   initializeTabSwitching();
   chrome.runtime.onMessage.addListener((message) => {

--- a/src/popup/styles/general.css
+++ b/src/popup/styles/general.css
@@ -71,3 +71,22 @@ h1 {
 .active {
   display: block;
 }
+
+/* Theme support */
+body.theme-light {
+  background-color: #f4f4f4;
+  color: #333;
+}
+
+body.theme-dark {
+  background-color: #1e1e1e;
+  color: #f4f4f4;
+}
+
+body.theme-dark .tab-button {
+  background-color: #444;
+}
+
+body.theme-dark .tab-button.active {
+  background-color: #222;
+}


### PR DESCRIPTION
## Summary
- load user theme in popup and toggle body class
- style new theme classes
- preload selected theme on options page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859089cea70832f9195b79753aeb1df