### PR TITLE
Improve tab selection using onCreated tab url

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -19,13 +19,22 @@ chrome.runtime.onInstalled.addListener(() => {
   }
 });
 
-chrome.tabs.onCreated.addListener(() => {
-  chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
-    if (!tabs || !tabs.length || !tabs[0].url) return;
-    const url = new URL(tabs[0].url);
+chrome.tabs.onCreated.addListener((tab) => {
+  const handleTabUrl = async (urlString) => {
+    const url = new URL(urlString);
     const target = (await isOnlineStore(url))
       ? "home-tab"
       : "store-discovery-tab";
     chrome.runtime.sendMessage({ action: "selectTab", target });
-  });
+  };
+
+  if (tab && tab.url) {
+    handleTabUrl(tab.url);
+  } else {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (tabs && tabs.length && tabs[0].url) {
+        handleTabUrl(tabs[0].url);
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- use the tab argument in `chrome.tabs.onCreated` to pick the active URL
- only query for the active tab if the event didn't include one

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686871b01d44832f949b3bea28a06f2d