### PR TITLE
Replace options alerts with inline status message

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -41,3 +41,16 @@ button {
 button:hover {
   background-color: #0056b3;
 }
+
+.status-message {
+  margin-top: 10px;
+  font-size: 0.9em;
+}
+
+.status-message.success {
+  color: #28a745;
+}
+
+.status-message.error {
+  color: #dc3545;
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -15,6 +15,7 @@
         <option value="dark">Dark</option>
       </select>
       <button id="save-settings">Save</button>
+      <div id="status-message" class="status-message"></div>
     </div>
     <script src="options.js"></script>
   </body>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,5 +1,18 @@
 document.addEventListener('DOMContentLoaded', () => {
   const themeSelect = document.getElementById('theme');
+  const statusMessage = document.getElementById('status-message');
+
+  const showMessage = (message, isError = false) => {
+    if (!statusMessage) return;
+    statusMessage.textContent = message;
+    statusMessage.classList.toggle('error', isError);
+    statusMessage.classList.toggle('success', !isError);
+    setTimeout(() => {
+      statusMessage.textContent = '';
+      statusMessage.classList.remove('error', 'success');
+    }, 3000);
+  };
+
   chrome.storage.sync.get('theme', ({ theme }) => {
     if (theme) {
       themeSelect.value = theme;
@@ -12,9 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const theme = themeSelect.value;
       chrome.storage.sync.set({ theme: theme }, () => {
         if (chrome.runtime.lastError) {
-          alert('Failed to save settings. Please try again.');
+          showMessage('Failed to save settings. Please try again.', true);
         } else {
-          alert('Settings saved!');
+          showMessage('Settings saved!', false);
         }
       });
     });


### PR DESCRIPTION
## Summary
- show a status message area on the options page
- style success/error message colors
- replace alert() calls with a less disruptive status message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686942601c10832f9c33212cf5a97c2c