### PR TITLE
Limit highlighting to known store domains

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,11 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["src/assets/data/stores.json", "src/assets/images/*"],
+      "resources": [
+        "src/assets/data/stores.json",
+        "src/assets/images/*",
+        "src/background/modules/urlUtils.js"
+      ],
       "matches": ["<all_urls>"]
     }
   ]

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,4 +1,11 @@
-(() => {
+(async () => {
+  const { isOnlineStore } = await import(
+    chrome.runtime.getURL('src/background/modules/urlUtils.js')
+  );
+  const currentUrl = new URL(window.location.href);
+  if (!(await isOnlineStore(currentUrl))) {
+    return;
+  }
 
   function highlightProductImages() {
     document.querySelectorAll('img').forEach((img) => {


### PR DESCRIPTION
## Summary
- import and use `isOnlineStore` in the content script
- only run the highlighting on recognized store domains
- expose `urlUtils.js` in manifest for content script access

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686942e5d1dc832fa3137c1a524fae0c