### PR TITLE
Add shared constant for store data path

### DIFF
--- a/src/background/modules/urlUtils.js
+++ b/src/background/modules/urlUtils.js
@@ -1,4 +1,4 @@
-const STORES_DATA_PATH = "src/assets/data/stores.json";
+import { STORES_DATA_PATH } from "../../shared/constants.js";
 let cachedDomains = null;
 
 export async function loadStoreDomains() {

--- a/src/popup/modules/storeService.js
+++ b/src/popup/modules/storeService.js
@@ -1,4 +1,6 @@
-export async function loadStores(dataUrl) {
+import { STORES_DATA_PATH } from "../../shared/constants.js";
+
+export async function loadStores(dataUrl = STORES_DATA_PATH) {
   try {
     const response = await fetch(chrome.runtime.getURL(dataUrl));
     if (!response.ok) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,4 +1,5 @@
 import { loadStores, applyFilters } from './modules/storeService.js';
+import { STORES_DATA_PATH } from '../shared/constants.js';
 import { renderStores, updateLoadMoreButton, generateCheckboxes, getCheckedValues } from './modules/ui.js';
 import { debounce } from './modules/debounce.js';
 import { addToWishlist, renderWishlist } from './modules/wishlist.js';
@@ -62,7 +63,7 @@ async function initializeApp() {
 
   let stores = [];
   try {
-    stores = await loadStores('src/assets/data/stores.json');
+    stores = await loadStores(STORES_DATA_PATH);
   } catch (error) {
     console.error(error);
     storeGrid.innerHTML = '<p>Unable to load stores. Please try again later.</p>';

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,0 +1,1 @@
+export const STORES_DATA_PATH = 'src/assets/data/stores.json';


### PR DESCRIPTION
## Summary
- centralize store data path constant
- use the shared constant in url utils and popup logic
- default `loadStores` to use this constant

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686961cdbc9c832f90d62e4bc7e6771b