### PR TITLE
Refactor popup initialization

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -55,159 +55,192 @@ function initializeTabSwitching() {
 }
 
 async function initializeApp() {
-  const storeGrid = document.getElementById('store-grid');
-  const loadMoreButton = document.getElementById('load-more');
-  const searchBar = document.getElementById('search-bar');
-  const filterButton = document.getElementById('filter-button');
-  const filterSection = document.getElementById('filter-section');
-
-  let stores = [];
+  const elements = {
+    storeGrid: document.getElementById('store-grid'),
+    loadMoreButton: document.getElementById('load-more'),
+    searchBar: document.getElementById('search-bar'),
+    filterButton: document.getElementById('filter-button'),
+    filterSection: document.getElementById('filter-section'),
+  };
+  let stores;
   try {
     stores = await loadStores(STORES_DATA_PATH);
   } catch (error) {
     console.error(error);
-    storeGrid.innerHTML = '<p>Unable to load stores. Please try again later.</p>';
+    elements.storeGrid.innerHTML = '<p>Unable to load stores. Please try again later.</p>';
     return;
   }
-  let filters = { targetDemographic: [], clothingType: [], priceRange: [] };
-  let displayedStores = 8;
-  let filteredStores = stores;
+  const state = {
+    stores,
+    filters: { targetDemographic: [], clothingType: [], priceRange: [] },
+    displayedStores: 8,
+    filteredStores: stores,
+  };
+  renderStores(elements.storeGrid, state.filteredStores, state.displayedStores);
+  updateLoadMoreButton(elements.loadMoreButton, state.displayedStores, state.filteredStores.length);
+  setupEventListeners(elements, state);
+}
 
-  renderStores(storeGrid, filteredStores, displayedStores);
-  updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
-  initializeEventListeners();
+function setupEventListeners(elements, state) {
+  setupSearchListener(elements, state);
+  setupLoadMoreListener(elements, state);
+  setupFilterToggle(elements, state);
+  setupWishlistListener();
+  setupAvatarToggle();
+  setupModelGridControls();
+}
 
-  function initializeEventListeners() {
-    searchBar.addEventListener(
-      'input',
-      debounce(() => {
-        filteredStores = applyFilters(stores, filters, searchBar.value);
-        displayedStores = 8;
-        renderStores(storeGrid, filteredStores, displayedStores);
-        updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
-      }, 300)
+function setupSearchListener({ searchBar, loadMoreButton, storeGrid }, state) {
+  const updateStoreList = () => {
+    renderStores(storeGrid, state.filteredStores, state.displayedStores);
+    updateLoadMoreButton(
+      loadMoreButton,
+      state.displayedStores,
+      state.filteredStores.length
     );
+  };
 
-    loadMoreButton.addEventListener('click', () => {
-      displayedStores += 8;
-      renderStores(storeGrid, filteredStores, displayedStores);
-      updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
-    });
+  searchBar.addEventListener(
+    'input',
+    debounce(() => {
+      state.filteredStores = applyFilters(
+        state.stores,
+        state.filters,
+        searchBar.value
+      );
+      state.displayedStores = 8;
+      updateStoreList();
+    }, 300)
+  );
+}
 
-    filterButton.addEventListener('click', () => {
-      filterSection.style.display = filterSection.style.display === 'none' ? 'block' : 'none';
-      if (filterSection.style.display === 'block') {
-        renderFilterOptions();
-      }
-    });
+function setupLoadMoreListener({ loadMoreButton, storeGrid }, state) {
+  loadMoreButton.addEventListener('click', () => {
+    state.displayedStores += 8;
+    renderStores(storeGrid, state.filteredStores, state.displayedStores);
+    updateLoadMoreButton(
+      loadMoreButton,
+      state.displayedStores,
+      state.filteredStores.length
+    );
+  });
+}
 
-    const wishlistBtn = document.querySelector('.wishlist-btn');
-    if (wishlistBtn) {
-      wishlistBtn.addEventListener('click', () => {
-        const item = {
-          name: document.querySelector('.product-name')?.textContent || '',
-          price: document.querySelector('.product-price')?.textContent || '',
-          clothingType: document.querySelector('.product-clothing-type')?.textContent || '',
-          imageSrc: document.querySelector('.product-image')?.getAttribute('src') || ''
-        };
-        addToWishlist(item);
-        if (document.getElementById('wishlist').classList.contains('active')) {
-          const grid = document.getElementById('wishlist-grid');
-          renderWishlist(grid);
-        }
-      });
+function setupFilterToggle(elements, state) {
+  const { filterButton, filterSection } = elements;
+  filterButton.addEventListener('click', () => {
+    filterSection.style.display =
+      filterSection.style.display === 'none' ? 'block' : 'none';
+    if (filterSection.style.display === 'block') renderFilterOptions(elements, state);
+  });
+}
+
+function setupWishlistListener() {
+  const wishlistBtn = document.querySelector('.wishlist-btn');
+  if (!wishlistBtn) return;
+  wishlistBtn.addEventListener('click', () => {
+    const item = {
+      name: document.querySelector('.product-name')?.textContent || '',
+      price: document.querySelector('.product-price')?.textContent || '',
+      clothingType: document.querySelector('.product-clothing-type')?.textContent || '',
+      imageSrc: document.querySelector('.product-image')?.getAttribute('src') || '',
+    };
+    addToWishlist(item);
+    if (document.getElementById('wishlist').classList.contains('active')) {
+      const grid = document.getElementById('wishlist-grid');
+      renderWishlist(grid);
     }
+  });
+}
 
-    const avatarSwatch = document.querySelector('.avatar-swatch');
-    const avatarSection = document.querySelector('.avatar-section');
-    if (avatarSwatch && avatarSection) {
-      avatarSwatch.addEventListener('click', () => {
-        avatarSection.style.display = avatarSection.style.display === 'none' ? 'block' : 'none';
-      });
-    }
-
-    const modelGrid = document.querySelector('.model-swatch-grid');
-    const leftBtn = document.querySelector('.left-btn');
-    const rightBtn = document.querySelector('.right-btn');
-
-    if (modelGrid) {
-      const updateButtons = () => {
-        if (leftBtn) leftBtn.disabled = modelGrid.scrollLeft <= 0;
-        if (rightBtn)
-          rightBtn.disabled =
-            modelGrid.scrollLeft + modelGrid.clientWidth >= modelGrid.scrollWidth;
-      };
-
-      if (leftBtn) {
-        leftBtn.addEventListener('click', () => {
-          modelGrid.scrollBy({ left: -100, behavior: 'smooth' });
-        });
-      }
-
-      if (rightBtn) {
-        rightBtn.addEventListener('click', () => {
-          modelGrid.scrollBy({ left: 100, behavior: 'smooth' });
-        });
-      }
-
-      modelGrid.addEventListener('scroll', updateButtons);
-      updateButtons();
-    }
-  }
-
-  function renderFilterOptions() {
-    filterSection.innerHTML = `
-      <h3>Target Demographic</h3>
-      ${generateCheckboxes(
-        'targetDemographic',
-        [...new Set(stores.flatMap((s) => s.targetDemographic))],
-        filters.targetDemographic
-      )}
-      <h3>Clothing Type</h3>
-      ${generateCheckboxes(
-        'clothingType',
-        [...new Set(stores.map((s) => s.clothingType))],
-        filters.clothingType
-      )}
-      <h3>Price Range</h3>
-      ${generateCheckboxes(
-        'priceRange',
-        [...new Set(stores.map((s) => s.priceRange))],
-        filters.priceRange
-      )}
-      <div class="filter-buttons">
-        <button id="apply-filters">Apply</button>
-        <button id="clear-filters">Clear</button>
-        <button id="close-filters">Exit</button>
-      </div>
-    `;
-
-    document.getElementById('apply-filters').addEventListener('click', () => {
-      filters = {
-        targetDemographic: getCheckedValues('targetDemographic'),
-        clothingType: getCheckedValues('clothingType'),
-        priceRange: getCheckedValues('priceRange'),
-      };
-      filteredStores = applyFilters(stores, filters, searchBar.value);
-      displayedStores = 8;
-      renderStores(storeGrid, filteredStores, displayedStores);
-      updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
-      filterSection.style.display = 'none';
-    });
-
-    document.getElementById('clear-filters').addEventListener('click', () => {
-      filters = { targetDemographic: [], clothingType: [], priceRange: [] };
-      filteredStores = applyFilters(stores, filters, searchBar.value);
-      displayedStores = 8;
-      renderStores(storeGrid, filteredStores, displayedStores);
-      updateLoadMoreButton(loadMoreButton, displayedStores, filteredStores.length);
-      filterSection.style.display = 'none';
-    });
-
-    document.getElementById('close-filters').addEventListener('click', () => {
-      filterSection.style.display = 'none';
+function setupAvatarToggle() {
+  const swatch = document.querySelector('.avatar-swatch');
+  const section = document.querySelector('.avatar-section');
+  if (swatch && section) {
+    swatch.addEventListener('click', () => {
+      section.style.display = section.style.display === 'none' ? 'block' : 'none';
     });
   }
+}
+
+function setupModelGridControls() {
+  const grid = document.querySelector('.model-swatch-grid');
+  const left = document.querySelector('.left-btn');
+  const right = document.querySelector('.right-btn');
+  if (!grid) return;
+  const updateButtons = () => {
+    if (left) left.disabled = grid.scrollLeft <= 0;
+    if (right) right.disabled = grid.scrollLeft + grid.clientWidth >= grid.scrollWidth;
+  };
+  if (left) left.addEventListener('click', () => grid.scrollBy({ left: -100, behavior: 'smooth' }));
+  if (right) right.addEventListener('click', () => grid.scrollBy({ left: 100, behavior: 'smooth' }));
+  grid.addEventListener('scroll', updateButtons);
+  updateButtons();
+}
+
+function renderFilterOptions(elements, state) {
+  const { filterSection, storeGrid, loadMoreButton, searchBar } = elements;
+  const { stores } = state;
+
+  filterSection.innerHTML = `
+    <h3>Target Demographic</h3>
+    ${generateCheckboxes(
+      'targetDemographic',
+      [...new Set(stores.flatMap((s) => s.targetDemographic))],
+      state.filters.targetDemographic
+    )}
+    <h3>Clothing Type</h3>
+    ${generateCheckboxes(
+      'clothingType',
+      [...new Set(stores.map((s) => s.clothingType))],
+      state.filters.clothingType
+    )}
+    <h3>Price Range</h3>
+    ${generateCheckboxes(
+      'priceRange',
+      [...new Set(stores.map((s) => s.priceRange))],
+      state.filters.priceRange
+    )}
+    <div class="filter-buttons">
+      <button id="apply-filters">Apply</button>
+      <button id="clear-filters">Clear</button>
+      <button id="close-filters">Exit</button>
+    </div>
+  `;
+
+  document.getElementById('apply-filters').addEventListener('click', () => {
+    state.filters = {
+      targetDemographic: getCheckedValues('targetDemographic'),
+      clothingType: getCheckedValues('clothingType'),
+      priceRange: getCheckedValues('priceRange'),
+    };
+    state.filteredStores = applyFilters(stores, state.filters, searchBar.value);
+    state.displayedStores = 8;
+    renderStores(storeGrid, state.filteredStores, state.displayedStores);
+    updateLoadMoreButton(
+      loadMoreButton,
+      state.displayedStores,
+      state.filteredStores.length
+    );
+    filterSection.style.display = 'none';
+  });
+
+  document.getElementById('clear-filters').addEventListener('click', () => {
+    state.filters = { targetDemographic: [], clothingType: [], priceRange: [] };
+    state.filteredStores = applyFilters(stores, state.filters, searchBar.value);
+    state.displayedStores = 8;
+    renderStores(storeGrid, state.filteredStores, state.displayedStores);
+    updateLoadMoreButton(
+      loadMoreButton,
+      state.displayedStores,
+      state.filteredStores.length
+    );
+    filterSection.style.display = 'none';
+  });
+
+  document.getElementById('close-filters').addEventListener('click', () => {
+    filterSection.style.display = 'none';
+  });
 }
 
 function initializeCollapsibleSections() {


### PR DESCRIPTION
## Summary
- move event listener setup to `setupEventListeners`
- add helper functions for wishlist, model grid, avatar and search
- keep `initializeApp` focused on data load
- extract filter rendering to `renderFilterOptions`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6869626e83a4832fad60cab9283236c6