### PR TITLE
Add centralized wishlist page and navigation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,8 @@
       "resources": [
         "src/assets/data/stores.json",
         "src/assets/images/*",
-        "src/background/modules/urlUtils.js"
+        "src/background/modules/urlUtils.js",
+        "src/popup/centralized-wishlist.html"
       ],
       "matches": ["<all_urls>"]
     }

--- a/src/popup/centralized-wishlist.html
+++ b/src/popup/centralized-wishlist.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Centralized Wishlist</title>
+    <link rel="stylesheet" href="styles/general.css" />
+    <link rel="stylesheet" href="styles/wishlist.css" />
+  </head>
+  <body class="theme-light">
+    <div class="container">
+      <h1>Centralized Wishlist</h1>
+      <p>This feature is coming soon.</p>
+    </div>
+  </body>
+</html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -88,6 +88,7 @@ function setupEventListeners(elements, state) {
   setupWishlistListener();
   setupAvatarToggle();
   setupModelGridControls();
+  setupCentralizedWishlistNavigation();
 }
 
 function setupSearchListener({ searchBar, loadMoreButton, storeGrid }, state) {
@@ -255,6 +256,19 @@ function initializeCollapsibleSections() {
         arrow.style.transform = isOpen ? 'rotate(90deg)' : 'rotate(0deg)';
       }
     });
+  });
+}
+
+function setupCentralizedWishlistNavigation() {
+  const btn = document.querySelector('.centralized-wishlist-btn');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const url = chrome.runtime.getURL('src/popup/centralized-wishlist.html');
+    if (chrome.tabs) {
+      chrome.tabs.create({ url });
+    } else {
+      window.open(url, '_blank');
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- create placeholder page for centralized wishlist
- expose the new page via manifest
- add click handler in popup.js to open the new page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68696679b034832fb456d8f49f39b951