### PR TITLE
Align options page style variables with popup

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,5 +1,5 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: "Poppins", sans-serif;
   background-color: var(--color-bg);
   color: var(--color-text);
   margin: 0;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../popup/styles/general.css" />
     <link rel="stylesheet" href="options.css" />
   </head>
-  <body>
+  <body class="theme-light">
     <div class="options-container">
       <h2>Settings</h2>
       <label for="theme">Choose Theme:</label>


### PR DESCRIPTION
## Summary
- default options page to `theme-light`
- use Poppins font in `options.css`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686969562108832f925a2c6353ae1722