### PR TITLE
Fix Amazon store link

### DIFF
--- a/src/assets/data/stores.json
+++ b/src/assets/data/stores.json
@@ -85,6 +85,6 @@
     "clothingType": "Activewear",
     "targetDemographic": ["Men", "Women", "Kids"],
     "priceRange": "Mid",
-    "url": "https://www.amazon.com/s?k=Trending+fashion&_encoding=UTF8&content-id=amzn1.sym.bad2a3cf-6397-46b0-aa92-6036dbc4afb6&crid=2787SXJYRXDZH&pd_rd_r=2152b504-4dd3-4558-8d8c-0986154c1c76&pd_rd_w=xDe1G&pd_rd_wg=UGnOT&pf_rd_p=bad2a3cf-6397-46b0-aa92-6036dbc4afb6&pf_rd_r=5QPXXAXQ30H42NCVBKKJ&sprefix=trending+fashion%2Caps%2C142&ref=pd_hp_d_atf_unk"
+    "url": "https://www.amazon.com/s?k=trending+fashion"
   }
 ]


### PR DESCRIPTION
## Summary
- shorten the Amazon URL in `stores.json`
- verify `loadStores()` still loads data (returns 11 stores)

## Testing
- `npm test` *(fails: no tests specified)*
- `node` script to invoke `loadStores` and print store count

------
https://chatgpt.com/codex/tasks/task_e_68696a1324ec832fb5827f9d6dc2a8d6