### PR TITLE
Fix store domain match and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/urlUtils.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/src/background/modules/urlUtils.js
+++ b/src/background/modules/urlUtils.js
@@ -21,5 +21,7 @@ export async function loadStoreDomains() {
 export async function isOnlineStore(url) {
   const onlineStoreDomains = await loadStoreDomains();
   const host = url.hostname.replace(/^www\./, "");
-  return onlineStoreDomains.some((domain) => host.includes(domain));
+  return onlineStoreDomains.some(
+    (domain) => host === domain || host.endsWith('.' + domain)
+  );
 }

--- a/test/urlUtils.test.mjs
+++ b/test/urlUtils.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+import fs from 'node:fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Mock chrome.runtime.getURL to return file URLs
+global.chrome = {
+  runtime: {
+    getURL: (p) => pathToFileURL(join(__dirname, '..', p)).href,
+  },
+};
+
+// Simple fetch mock for file URLs
+global.fetch = async (url) => {
+  if (url.startsWith('file://')) {
+    const data = await fs.readFile(new URL(url), 'utf8');
+    return { json: async () => JSON.parse(data) };
+  }
+  throw new Error('Unsupported protocol in test fetch');
+};
+
+import { isOnlineStore } from '../src/background/modules/urlUtils.js';
+
+async function runTests() {
+  const realUrl = new URL('https://www.zara.com');
+  assert.equal(await isOnlineStore(realUrl), true, 'recognizes real domain');
+
+  const subdomainUrl = new URL('https://shop.zara.com');
+  assert.equal(await isOnlineStore(subdomainUrl), true, 'recognizes subdomain');
+
+  const fakeUrl = new URL('https://zaracom.com');
+  assert.equal(await isOnlineStore(fakeUrl), false, 'ignores similar fake domain');
+
+  const trickyUrl = new URL('https://zara.com.fake.com');
+  assert.equal(await isOnlineStore(trickyUrl), false, 'ignores domain within larger host');
+
+  console.log('All tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- restrict domain matching in `urlUtils` to exact matches or subdomains
- add unit tests for real and fake store domains
- run tests with Node

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68696d0c8838832fa087869b1c63e878