### PR TITLE
Enable ESM by declaring module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "chrome-extension",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "node test/urlUtils.test.mjs"


### PR DESCRIPTION
## Summary
- enable ES module support by adding `"type": "module"` to package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697556900c832fadfac0bf726b09a1