### PR TITLE
Add centralized wishlist view

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,13 @@
     "48": "src/assets/icons/icon48.png",
     "128": "src/assets/icons/icon128.png"
   },
-  "permissions": ["sidePanel", "storage", "tabs", "activeTab", "scripting"],
+  "permissions": [
+    "sidePanel",
+    "storage",
+    "tabs",
+    "activeTab",
+    "scripting"
+  ],
   "background": {
     "service_worker": "src/background/background.js",
     "type": "module"
@@ -25,8 +31,12 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["src/content/content.js"],
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "src/content/content.js"
+      ],
       "run_at": "document_idle"
     }
   ],
@@ -36,9 +46,12 @@
         "src/assets/data/stores.json",
         "src/assets/images/*",
         "src/background/modules/urlUtils.js",
-        "src/popup/centralized-wishlist.html"
+        "src/popup/centralized-wishlist.html",
+        "src/popup/centralized-wishlist.js"
       ],
-      "matches": ["<all_urls>"]
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ]
 }

--- a/src/popup/centralized-wishlist.html
+++ b/src/popup/centralized-wishlist.html
@@ -10,7 +10,8 @@
   <body class="theme-light">
     <div class="container">
       <h1>Centralized Wishlist</h1>
-      <p>This feature is coming soon.</p>
+      <div id="wishlist-grid" class="wishlist-grid"></div>
     </div>
+    <script type="module" src="centralized-wishlist.js"></script>
   </body>
 </html>

--- a/src/popup/centralized-wishlist.js
+++ b/src/popup/centralized-wishlist.js
@@ -1,0 +1,10 @@
+import { renderWishlist } from './modules/wishlist.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.sync.get('theme', ({ theme }) => {
+    document.body.classList.remove('theme-dark', 'theme-light');
+    document.body.classList.add(theme === 'dark' ? 'theme-dark' : 'theme-light');
+  });
+  const container = document.getElementById('wishlist-grid');
+  renderWishlist(container);
+});


### PR DESCRIPTION
## Summary
- display wishlist items in `centralized-wishlist.html`
- implement `centralized-wishlist.js` to render stored wishlist items
- expose new script via `web_accessible_resources`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686975603a84832fbb9eb75383bbf1ae