### PR TITLE
Improve wishlist error handling

### DIFF
--- a/src/popup/modules/wishlist.js
+++ b/src/popup/modules/wishlist.js
@@ -1,75 +1,98 @@
 export async function getWishlist() {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     chrome.storage.local.get({ wishlist: [] }, (result) => {
-      resolve(result.wishlist);
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        resolve(result.wishlist);
+      }
     });
   });
 }
 
 export async function saveWishlist(items) {
-  return new Promise((resolve) => {
-    chrome.storage.local.set({ wishlist: items }, () => resolve());
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set({ wishlist: items }, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        resolve();
+      }
+    });
   });
 }
 
 export async function addToWishlist(item) {
-  const list = await getWishlist();
-  list.push({ ...item, dateAdded: new Date().toISOString() });
-  await saveWishlist(list);
+  try {
+    const list = await getWishlist();
+    list.push({ ...item, dateAdded: new Date().toISOString() });
+    await saveWishlist(list);
+  } catch (error) {
+    console.error('Failed to add item to wishlist:', error);
+  }
 }
 
 export async function removeFromWishlist(dateAdded) {
-  const list = await getWishlist();
-  const filtered = list.filter((item) => item.dateAdded !== dateAdded);
-  await saveWishlist(filtered);
-  return filtered;
+  try {
+    const list = await getWishlist();
+    const filtered = list.filter((item) => item.dateAdded !== dateAdded);
+    await saveWishlist(filtered);
+    return filtered;
+  } catch (error) {
+    console.error('Failed to remove item from wishlist:', error);
+    return [];
+  }
 }
 
 export async function renderWishlist(container) {
-  const items = await getWishlist();
-  if (!container) return;
-  container.innerHTML = '';
-  items.forEach((item) => {
-    const div = document.createElement('div');
-    div.className = 'wishlist-item';
+  try {
+    const items = await getWishlist();
+    if (!container) return;
+    container.innerHTML = '';
+    items.forEach((item) => {
+      const div = document.createElement('div');
+      div.className = 'wishlist-item';
+      const img = document.createElement('img');
+      img.src = chrome.runtime.getURL(item.imageSrc);
+      img.alt = item.name;
+      div.appendChild(img);
 
-    const img = document.createElement('img');
-    img.src = chrome.runtime.getURL(item.imageSrc);
-    img.alt = item.name;
-    div.appendChild(img);
+      const nameP = document.createElement('p');
+      nameP.textContent = `${item.name} - ${item.price}`;
+      div.appendChild(nameP);
 
-    const nameP = document.createElement('p');
-    nameP.textContent = `${item.name} - ${item.price}`;
-    div.appendChild(nameP);
+      const dateP = document.createElement('p');
+      dateP.textContent = `Date Added: ${new Date(item.dateAdded).toLocaleDateString()}`;
+      div.appendChild(dateP);
 
-    const dateP = document.createElement('p');
-    dateP.textContent = `Date Added: ${new Date(item.dateAdded).toLocaleDateString()}`;
-    div.appendChild(dateP);
+      const tryBtn = document.createElement('button');
+      tryBtn.className = 'try-on-btn';
+      tryBtn.textContent = 'Try On';
+      div.appendChild(tryBtn);
 
-    const tryBtn = document.createElement('button');
-    tryBtn.className = 'try-on-btn';
-    tryBtn.textContent = 'Try On';
-    div.appendChild(tryBtn);
+      if (item.url) {
+        const visitBtn = document.createElement('button');
+        visitBtn.className = 'visit-page-btn';
+        visitBtn.textContent = 'Visit Page';
+        visitBtn.addEventListener('click', () => {
+          chrome.tabs.create({ url: item.url });
+        });
+        div.appendChild(visitBtn);
+      }
 
-    if (item.url) {
-      const visitBtn = document.createElement('button');
-      visitBtn.className = 'visit-page-btn';
-      visitBtn.textContent = 'Visit Page';
-      visitBtn.addEventListener('click', () => {
-        chrome.tabs.create({ url: item.url });
+      const removeBtn = document.createElement('button');
+      removeBtn.className = 'remove-btn';
+      removeBtn.textContent = 'Remove';
+      removeBtn.addEventListener('click', async () => {
+        await removeFromWishlist(item.dateAdded);
+        renderWishlist(container);
       });
-      div.appendChild(visitBtn);
-    }
+      div.appendChild(removeBtn);
 
-    const removeBtn = document.createElement('button');
-    removeBtn.className = 'remove-btn';
-    removeBtn.textContent = 'Remove';
-    removeBtn.addEventListener('click', async () => {
-      await removeFromWishlist(item.dateAdded);
-      renderWishlist(container);
+      container.appendChild(div);
     });
-    div.appendChild(removeBtn);
-
-    container.appendChild(div);
-  });
+  } catch (error) {
+    console.error('Failed to render wishlist:', error);
+    if (container) container.innerHTML = '<p>Error loading wishlist.</p>';
+  }
 }


### PR DESCRIPTION
## Summary
- handle `chrome.runtime.lastError` after getting or saving wishlist data
- log failures in wishlist operations so popup doesn't break

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869774bc218832f904a19a0df36780d