### PR TITLE
Fix wishlist img url handling

### DIFF
--- a/src/popup/modules/wishlist.js
+++ b/src/popup/modules/wishlist.js
@@ -53,7 +53,9 @@ export async function renderWishlist(container) {
       const div = document.createElement('div');
       div.className = 'wishlist-item';
       const img = document.createElement('img');
-      img.src = chrome.runtime.getURL(item.imageSrc);
+      img.src = /^https?:\/\//.test(item.imageSrc)
+        ? item.imageSrc
+        : chrome.runtime.getURL(item.imageSrc);
       img.alt = item.name;
       div.appendChild(img);
 


### PR DESCRIPTION
## Summary
- handle absolute URLs when rendering wishlist

## Testing
- `npm test`
- `npm run lint` *(fails: `'chrome' is not defined` errors)*

------
https://chatgpt.com/codex/tasks/task_e_68697d51fc3c832f894ecc1c3e276fa4