### PR TITLE
Add theme update listener

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -21,6 +21,17 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.classList.add(theme === 'dark' ? 'theme-dark' : 'theme-light');
   });
 
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'sync' && changes.theme) {
+      const theme = changes.theme.newValue;
+      if (themeSelect) themeSelect.value = theme;
+      document.body.classList.remove('theme-dark', 'theme-light');
+      document.body.classList.add(
+        theme === 'dark' ? 'theme-dark' : 'theme-light'
+      );
+    }
+  });
+
   document
     .getElementById('save-settings')
     .addEventListener('click', () => {

--- a/src/popup/centralized-wishlist.js
+++ b/src/popup/centralized-wishlist.js
@@ -5,6 +5,16 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.classList.remove('theme-dark', 'theme-light');
     document.body.classList.add(theme === 'dark' ? 'theme-dark' : 'theme-light');
   });
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'sync' && changes.theme) {
+      const theme = changes.theme.newValue;
+      document.body.classList.remove('theme-dark', 'theme-light');
+      document.body.classList.add(
+        theme === 'dark' ? 'theme-dark' : 'theme-light'
+      );
+    }
+  });
   const container = document.getElementById('wishlist-grid');
   renderWishlist(container);
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -10,6 +10,16 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.classList.add(theme === 'dark' ? 'theme-dark' : 'theme-light');
   });
 
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'sync' && changes.theme) {
+      const theme = changes.theme.newValue;
+      document.body.classList.remove('theme-dark', 'theme-light');
+      document.body.classList.add(
+        theme === 'dark' ? 'theme-dark' : 'theme-light'
+      );
+    }
+  });
+
   initializeApp();
   initializeTabSwitching();
   initializeCollapsibleSections();


### PR DESCRIPTION
## Summary
- refresh theme when storage changes in popup, options, and wishlist pages

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68697e9be664832f9a66f1c0c142c0a8