### PR TITLE
Add photo storage module with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/urlUtils.test.mjs",
+    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs",
     "lint": "eslint src test"
   },
   "keywords": [],

--- a/src/popup/modules/photoStorage.js
+++ b/src/popup/modules/photoStorage.js
@@ -1,0 +1,67 @@
+export async function addPhoto(file) {
+  const toDataUrl = async (f) => {
+    if (typeof f === 'string') return f;
+    if (f.arrayBuffer) {
+      const buffer = Buffer.from(await f.arrayBuffer());
+      const mime = f.type || 'application/octet-stream';
+      return `data:${mime};base64,${buffer.toString('base64')}`;
+    }
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(f);
+    });
+  };
+
+  const dataUrl = await toDataUrl(file);
+  const photo = { id: Date.now(), dataUrl };
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get({ photos: [] }, (result) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        const photos = result.photos;
+        photos.push(photo);
+        chrome.storage.local.set({ photos }, () => {
+          if (chrome.runtime.lastError) {
+            reject(chrome.runtime.lastError);
+          } else {
+            resolve(photo);
+          }
+        });
+      }
+    });
+  });
+}
+
+export function getPhotos() {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get({ photos: [] }, (result) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+      } else {
+        resolve(result.photos);
+      }
+    });
+  });
+}
+
+export function deletePhoto(id) {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get({ photos: [] }, (result) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      const filtered = result.photos.filter((p) => p.id !== id);
+      chrome.storage.local.set({ photos: filtered }, () => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+        } else {
+          resolve(filtered);
+        }
+      });
+    });
+  });
+}

--- a/test/photoStorage.test.mjs
+++ b/test/photoStorage.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { Blob } from 'node:buffer';
+
+// Simple chrome.storage mock
+const storage = { photos: [] };
+
+global.chrome = {
+  runtime: { lastError: null },
+  storage: {
+    local: {
+      get(query, cb) {
+        const result = {};
+        for (const key in query) {
+          result[key] = key in storage ? storage[key] : query[key];
+        }
+        cb(result);
+      },
+      set(items, cb) {
+        Object.assign(storage, items);
+        cb && cb();
+      },
+    },
+  },
+};
+
+import { addPhoto, getPhotos, deletePhoto } from '../src/popup/modules/photoStorage.js';
+
+async function runTests() {
+  const blob = new Blob(['hello'], { type: 'text/plain' });
+  const added = await addPhoto(blob);
+  assert.ok(added.id, 'photo has id');
+  const list = await getPhotos();
+  assert.equal(list.length, 1, 'photo added');
+  assert.equal(list[0].id, added.id, 'id matches');
+
+  await deletePhoto(added.id);
+  const afterDelete = await getPhotos();
+  assert.equal(afterDelete.length, 0, 'photo deleted');
+  console.log('All tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- implement photo management using `chrome.storage.local`
- test photo storage operations with mocked `chrome.storage`
- run all tests sequentially via npm script

## Testing
- `npm test`
- `node test/photoStorage.test.mjs`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686992b838a8832fa2b46d312388ddc4