### PR TITLE
Add store info to wishlist items

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,4 +1,5 @@
 import { isOnlineStore, loadStoreDomains } from "./modules/urlUtils.js";
+import { addToWishlist } from "../popup/modules/wishlist.js";
 
 function createContextMenus() {
   if (!chrome.contextMenus) return;
@@ -19,11 +20,19 @@ function createContextMenus() {
 createContextMenus();
 chrome.runtime.onStartup.addListener(createContextMenus);
 
-chrome.contextMenus.onClicked.addListener((info) => {
+chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === 'imagine-try-on') {
     chrome.runtime.sendMessage({ action: 'contextTryOn', srcUrl: info.srcUrl });
   } else if (info.menuItemId === 'imagine-add-wishlist') {
-    chrome.runtime.sendMessage({ action: 'contextAddWishlist', srcUrl: info.srcUrl });
+    const pageUrl = info.pageUrl || (tab && tab.url) || '';
+    addToWishlist({
+      name: '',
+      price: '',
+      clothingType: '',
+      imageSrc: info.srcUrl,
+      url: pageUrl,
+      storeName: pageUrl ? new URL(pageUrl).hostname.replace(/^www\./, '') : '',
+    });
   }
 });
 

--- a/src/popup/centralized-wishlist.html
+++ b/src/popup/centralized-wishlist.html
@@ -10,6 +10,7 @@
   <body class="theme-light">
     <div class="container">
       <h1>Centralized Wishlist</h1>
+      <p class="instructions">Use the buttons below each item to visit the original product page.</p>
       <div id="wishlist-grid" class="wishlist-grid"></div>
     </div>
     <script type="module" src="centralized-wishlist.js"></script>

--- a/src/popup/modules/wishlist.js
+++ b/src/popup/modules/wishlist.js
@@ -3,7 +3,7 @@ import { getSelectedPhotoId } from './photoStorage.js';
 
 export async function getWishlist() {
   return new Promise((resolve, reject) => {
-    chrome.storage.local.get({ wishlist: [] }, (result) => {
+    chrome.storage.sync.get({ wishlist: [] }, (result) => {
       if (chrome.runtime.lastError) {
         reject(chrome.runtime.lastError);
       } else {
@@ -15,7 +15,7 @@ export async function getWishlist() {
 
 export async function saveWishlist(items) {
   return new Promise((resolve, reject) => {
-    chrome.storage.local.set({ wishlist: items }, () => {
+    chrome.storage.sync.set({ wishlist: items }, () => {
       if (chrome.runtime.lastError) {
         reject(chrome.runtime.lastError);
       } else {
@@ -63,8 +63,20 @@ export async function renderWishlist(container) {
       div.appendChild(img);
 
       const nameP = document.createElement('p');
-      nameP.textContent = `${item.name} - ${item.price}`;
+      nameP.textContent = item.name;
       div.appendChild(nameP);
+
+      if (item.storeName) {
+        const storeP = document.createElement('p');
+        storeP.textContent = item.storeName;
+        div.appendChild(storeP);
+      }
+
+      if (item.price) {
+        const priceP = document.createElement('p');
+        priceP.textContent = item.price;
+        div.appendChild(priceP);
+      }
 
       const dateP = document.createElement('p');
       dateP.textContent = `Date Added: ${new Date(item.dateAdded).toLocaleDateString()}`;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -166,6 +166,8 @@ function setupWishlistListener() {
       price: document.querySelector('.product-price')?.textContent || '',
       clothingType: document.querySelector('.product-clothing-type')?.textContent || '',
       imageSrc: document.querySelector('.product-image')?.getAttribute('src') || '',
+      url: window.location.href,
+      storeName: window.location.hostname.replace(/^www\./, ''),
     };
     addToWishlist(item);
     if (document.getElementById('wishlist').classList.contains('active')) {


### PR DESCRIPTION
## Summary
- switch wishlist storage to chrome.storage.sync so lists sync across sites
- include `url`, `storeName`, and `price` fields when saving an item
- record these fields when clicking the wishlist button
- allow adding items via context menu in the background worker
- display store and price in wishlist UI
- add note in centralized wishlist page

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/eslintrc`)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68699728f674832f9ba53e8a7e42bad6