### PR TITLE
Add context try-on dialog

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -22,7 +22,24 @@ chrome.runtime.onStartup.addListener(createContextMenus);
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === 'imagine-try-on') {
-    chrome.runtime.sendMessage({ action: 'contextTryOn', srcUrl: info.srcUrl });
+    const notifyPanel = () =>
+      chrome.runtime.sendMessage({ action: 'contextTryOn', srcUrl: info.srcUrl });
+
+    if (chrome.sidePanel && chrome.sidePanel.open) {
+      // Open the extension side panel if supported
+      chrome.sidePanel.open({ windowId: tab?.windowId }, notifyPanel);
+    } else {
+      // Fallback: open the popup window
+      chrome.windows.create(
+        {
+          url: chrome.runtime.getURL('src/popup/popup.html'),
+          type: 'popup',
+          width: 400,
+          height: 600,
+        },
+        notifyPanel,
+      );
+    }
   } else if (info.menuItemId === 'imagine-add-wishlist') {
     const pageUrl = info.pageUrl || (tab && tab.url) || '';
     addToWishlist({

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -10,6 +10,7 @@ import {
   getSelectedPhotoId,
   setSelectedPhotoId,
 } from './modules/photoStorage.js';
+import { requestTryOn } from './modules/tryOnService.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   chrome.storage.sync.get('theme', ({ theme }) => {
@@ -34,6 +35,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (message.action === 'selectTab') {
       const button = document.getElementById(message.target);
       if (button) button.click();
+    }
+    if (message.action === 'contextTryOn') {
+      const tabButton = document.getElementById('dressing-room-tab');
+      if (tabButton) tabButton.click();
+      if (message.srcUrl) showPhotoDialog(message.srcUrl);
     }
   });
 });
@@ -366,6 +372,56 @@ function renderPhotoGallery(container, photos, selectedId) {
 
     container.appendChild(item);
   });
+}
+
+async function showPhotoDialog(clothingUrl) {
+  const photos = await getPhotos();
+  if (!photos.length) {
+    alert('Please upload a photo in the Dressing Room first.');
+    return;
+  }
+
+  const overlay = document.createElement('div');
+  overlay.className = 'photo-dialog-overlay';
+
+  const dialog = document.createElement('div');
+  dialog.className = 'photo-dialog';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Cancel';
+  closeBtn.addEventListener('click', () => overlay.remove());
+  dialog.appendChild(closeBtn);
+
+  photos.forEach((p) => {
+    const option = document.createElement('div');
+    option.className = 'photo-option';
+
+    const img = document.createElement('img');
+    img.src = p.dataUrl;
+    option.appendChild(img);
+
+    const btn = document.createElement('button');
+    btn.textContent = 'Try On';
+    btn.addEventListener('click', async () => {
+      overlay.remove();
+      try {
+        const url = await requestTryOn(p.id, clothingUrl);
+        if (chrome.tabs) {
+          chrome.tabs.create({ url });
+        } else {
+          window.open(url, '_blank');
+        }
+      } catch (e) {
+        alert(e.message);
+      }
+    });
+    option.appendChild(btn);
+
+    dialog.appendChild(option);
+  });
+
+  overlay.appendChild(dialog);
+  document.body.appendChild(overlay);
 }
 
 

--- a/src/popup/styles/dressing-room.css
+++ b/src/popup/styles/dressing-room.css
@@ -228,3 +228,35 @@
   background-color: var(--color-error);
   color: var(--color-card);
 }
+
+/* Overlay dialog for selecting photo when trying on from context menu */
+.photo-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.photo-dialog {
+  background: var(--color-card);
+  padding: 20px;
+  border-radius: 8px;
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.photo-option {
+  display: inline-block;
+  margin: 5px;
+  text-align: center;
+}
+
+.photo-option img {
+  max-width: 100px;
+  border-radius: 8px;
+  display: block;
+  margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- open the side panel or popup when using the context menu
- show a photo selection dialog in the side panel
- generate the try-on image with the selected photo

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68699a869570832fb0833eab6ba56da1