### PR TITLE
Implement DOM product info retrieval

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -20,4 +20,72 @@
   } else {
     highlightProductImages();
   }
+
+  function textFromSelectors(selectors) {
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (el) {
+        const txt = el.textContent?.trim();
+        if (txt) return txt;
+      }
+    }
+    return '';
+  }
+
+  function collectColors() {
+    const elements = document.querySelectorAll(
+      '[itemprop="color"], [class*="color"] option, select[name*="color"] option, [data-color]'
+    );
+    const colors = [];
+    elements.forEach((el) => {
+      const val =
+        el.getAttribute('data-color') || el.textContent?.trim() || el.style.backgroundColor;
+      if (val && !colors.includes(val)) colors.push(val);
+    });
+    return colors;
+  }
+
+  function collectSimilar() {
+    const container = document.querySelector(
+      '.similar-products, .related-products, [class*="similar"], [class*="related"]'
+    );
+    const items = [];
+    if (container) {
+      container.querySelectorAll('a img').forEach((img) => {
+        const link = img.closest('a');
+        if (img.src) {
+          items.push({ link: link ? link.href : '', image: img.src });
+        }
+      });
+    }
+    return items;
+  }
+
+  function extractProductInfo() {
+    return {
+      name: textFromSelectors(['[itemprop="name"]', 'h1', 'meta[property="og:title"]']),
+      price: textFromSelectors(['[itemprop="price"]', '.price', '[class*="price"]']),
+      colors: collectColors(),
+      details: textFromSelectors([
+        '[itemprop="description"]',
+        '.product-description',
+        '[id*="description"]',
+      ]),
+      rating: textFromSelectors(['[itemprop="ratingValue"]', '.rating']),
+      reviews: textFromSelectors(['[itemprop="reviewCount"]', '.review-count', '[class*="review"]']),
+      clothingType: textFromSelectors(['[itemprop="category"]']),
+      image:
+        document.querySelector('[itemprop="image"]')?.src ||
+        document.querySelector('meta[property="og:image"]')?.content ||
+        document.querySelector('img')?.src ||
+        '',
+      similar: collectSimilar(),
+    };
+  }
+
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.action === 'getProductInfo') {
+      sendResponse(extractProductInfo());
+    }
+  });
 })();

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -69,6 +69,9 @@ function initializeTabSwitching() {
     if (targetContentId === 'dressing-room') {
       loadAndRenderPhotos();
     }
+    if (targetContentId === 'product-discovery') {
+      loadProductInfo();
+    }
   };
 
   tabButtons.forEach((button) => {
@@ -449,6 +452,82 @@ async function showPhotoDialog(clothingUrl) {
 
   overlay.appendChild(dialog);
   document.body.appendChild(overlay);
+}
+
+function requestProductInfo() {
+  return new Promise((resolve) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (!tabs || !tabs[0]) return resolve(null);
+      chrome.tabs.sendMessage(tabs[0].id, { action: 'getProductInfo' }, (res) => {
+        resolve(res);
+      });
+    });
+  });
+}
+
+async function loadProductInfo() {
+  try {
+    const info = await requestProductInfo();
+    if (info) renderProductInfo(info);
+  } catch (e) {
+    console.error('Failed to load product info', e);
+  }
+}
+
+function renderProductInfo(info) {
+  const imageEl = document.querySelector('.product-image');
+  if (imageEl && info.image) imageEl.src = info.image;
+  const nameEl = document.querySelector('.product-name');
+  if (nameEl && info.name) nameEl.textContent = info.name;
+  const priceEl = document.querySelector('.product-price');
+  if (priceEl && info.price) priceEl.textContent = info.price;
+  const typeEl = document.querySelector('.product-clothing-type');
+  if (typeEl && info.clothingType) typeEl.textContent = info.clothingType;
+
+  const colorGrid = document.querySelector('.color-grid');
+  if (colorGrid && Array.isArray(info.colors)) {
+    colorGrid.innerHTML = '';
+    info.colors.forEach((c) => {
+      const swatch = document.createElement('div');
+      swatch.className = 'color-swatch';
+      swatch.style.backgroundColor = c;
+      colorGrid.appendChild(swatch);
+    });
+  }
+
+  const sections = document.querySelectorAll('.collapsible-section .collapsible-content');
+  if (sections[0] && info.details) {
+    sections[0].textContent = info.details;
+  }
+  if (sections[1]) {
+    sections[1].innerHTML = '';
+    if (info.rating) {
+      const p = document.createElement('p');
+      p.textContent = info.rating;
+      sections[1].appendChild(p);
+    }
+    if (info.reviews) {
+      const p = document.createElement('p');
+      p.textContent = info.reviews;
+      sections[1].appendChild(p);
+    }
+  }
+
+  const grid = document.querySelector('.similar-products-grid');
+  if (grid && Array.isArray(info.similar)) {
+    grid.innerHTML = '';
+    info.similar.forEach((item) => {
+      const div = document.createElement('div');
+      div.className = 'similar-product-item';
+      const link = document.createElement('a');
+      if (item.link) link.href = item.link;
+      const img = document.createElement('img');
+      img.src = item.image;
+      link.appendChild(img);
+      div.appendChild(link);
+      grid.appendChild(div);
+    });
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- parse product details in `content.js` when requested
- request product details from the popup
- render product details and similar products

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869a5600e68832fb1b1f22eaedd3ab1