### PR TITLE
Add recommended products extraction

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -45,20 +45,29 @@
     return colors;
   }
 
-  function collectSimilar() {
-    const container = document.querySelector(
-      '.similar-products, .related-products, [class*="similar"], [class*="related"]'
+  function collectRecommended() {
+    const containers = document.querySelectorAll(
+      '.recommended-products, .similar-products, .related-products, [class*="recommended"], [class*="similar"], [class*="related"]'
     );
     const items = [];
-    if (container) {
-      container.querySelectorAll('a img').forEach((img) => {
-        const link = img.closest('a');
-        if (img.src) {
-          items.push({ link: link ? link.href : '', image: img.src });
-        }
+    containers.forEach((container) => {
+      container.querySelectorAll('a').forEach((a) => {
+        const img = a.querySelector('img');
+        if (!img || !img.src) return;
+        const name = img.getAttribute('alt') || a.textContent.trim();
+        items.push({ url: a.href || '', image: img.src, name });
       });
-    }
-    return items;
+    });
+    const unique = [];
+    const seen = new Set();
+    items.forEach((item) => {
+      const key = `${item.url}|${item.image}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        unique.push(item);
+      }
+    });
+    return unique;
   }
 
   function collectRatingValue() {
@@ -102,7 +111,7 @@
         document.querySelector('meta[property="og:image"]')?.content ||
         document.querySelector('img')?.src ||
         '',
-      similar: collectSimilar(),
+      recommended: collectRecommended(),
     };
   }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -531,17 +531,26 @@ function renderProductInfo(info) {
 
   const grid = document.querySelector('.similar-products-grid');
   const section = grid?.closest('.similar-products-section');
-  if (grid && Array.isArray(info.similar) && info.similar.length) {
+  if (grid && Array.isArray(info.recommended) && info.recommended.length) {
     grid.innerHTML = '';
-    info.similar.forEach((item) => {
+    info.recommended.forEach((item) => {
       const div = document.createElement('div');
       div.className = 'similar-product-item';
+
       const link = document.createElement('a');
-      if (item.link) link.href = item.link;
+      if (item.url) link.href = item.url;
+
       const img = document.createElement('img');
       img.src = item.image;
       link.appendChild(img);
       div.appendChild(link);
+
+      if (item.name) {
+        const p = document.createElement('p');
+        p.textContent = item.name;
+        div.appendChild(p);
+      }
+
       grid.appendChild(div);
     });
     if (section) section.style.display = '';


### PR DESCRIPTION
## Summary
- parse recommended products from content pages including image, name and URL
- show these recommended items in the popup "Similar Products" section

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6869ad626edc832f85dc3f0c9740f0b7