### PR TITLE
Add wishlist toggle test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs",
+    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs && node test/wishlist.test.mjs",
     "lint": "eslint src test"
   },
   "keywords": [],

--- a/test/wishlist.test.mjs
+++ b/test/wishlist.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+
+// In-memory chrome.storage.sync mock
+const storage = { wishlist: [] };
+
+global.chrome = {
+  runtime: { lastError: null },
+  storage: {
+    sync: {
+      get(query, cb) {
+        const result = {};
+        for (const key in query) {
+          result[key] = key in storage ? storage[key] : query[key];
+        }
+        cb(result);
+      },
+      set(items, cb) {
+        Object.assign(storage, items);
+        cb && cb();
+      },
+    },
+  },
+};
+
+import { toggleWishlist, getWishlist } from '../src/popup/modules/wishlist.js';
+
+async function runTests() {
+  const item = {
+    url: 'https://example.com/product/1',
+    imageSrc: 'https://example.com/img1.png',
+    name: 'Test Item',
+  };
+
+  let result = await toggleWishlist(item);
+  assert.equal(result, true, 'added on first toggle');
+  let list = await getWishlist();
+  assert.equal(list.length, 1, 'wishlist has one item');
+
+  result = await toggleWishlist(item);
+  assert.equal(result, false, 'removed on second toggle');
+  list = await getWishlist();
+  assert.equal(list.length, 0, 'wishlist empty after removal');
+
+  result = await toggleWishlist(item);
+  assert.equal(result, true, 'added again after removal');
+  list = await getWishlist();
+  assert.equal(list.length, 1, 'wishlist has one item again');
+
+  result = await toggleWishlist(item);
+  assert.equal(result, false, 'removed again on final toggle');
+  list = await getWishlist();
+  assert.equal(list.length, 0, 'wishlist empty at end');
+
+  console.log('All tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- add tests for the wishlist toggle logic
- mock `chrome.storage.sync` in the new test
- run new test via npm script

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869ae2dcc28832f937f0ff922cf5546