### PR TITLE
Fix extension errors and static try-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ npm run lint
 ```
 
 The lint script checks the `src` and `test` directories using ESLint.
+
+## Try-On Feature
+
+The virtual try-on API is not yet integrated. Calls to `requestTryOn` currently
+return a static placeholder image. Once the backend is available, this module
+can be updated to communicate with the service.

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -23,7 +23,14 @@ chrome.runtime.onStartup.addListener(createContextMenus);
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === 'imagine-try-on') {
     const notifyPanel = () =>
-      chrome.runtime.sendMessage({ action: 'contextTryOn', srcUrl: info.srcUrl });
+      chrome.runtime.sendMessage(
+        { action: 'contextTryOn', srcUrl: info.srcUrl },
+        () => {
+          if (chrome.runtime.lastError) {
+            // Ignore errors when no listener is available
+          }
+        },
+      );
 
     if (chrome.sidePanel && chrome.sidePanel.open) {
       // Open the extension side panel if supported
@@ -80,7 +87,11 @@ chrome.tabs.onCreated.addListener((tab) => {
     const target = (await isOnlineStore(url))
       ? "home-tab"
       : "store-discovery-tab";
-    chrome.runtime.sendMessage({ action: "selectTab", target });
+    chrome.runtime.sendMessage({ action: "selectTab", target }, () => {
+      if (chrome.runtime.lastError) {
+        // Ignore errors when no listener is available
+      }
+    });
   };
 
   if (tab && tab.url) {

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,123 +1,127 @@
 (async () => {
-  const { isOnlineStore } = await import(
-    chrome.runtime.getURL('src/background/modules/urlUtils.js')
-  );
-  const currentUrl = new URL(window.location.href);
-  if (!(await isOnlineStore(currentUrl))) {
-    return;
-  }
-
-  function highlightProductImages() {
-    document.querySelectorAll('img').forEach((img) => {
-      if (img.naturalWidth > 100 && img.naturalHeight > 100) {
-        img.style.outline = '2px solid #ff6600';
-      }
-    });
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', highlightProductImages);
-  } else {
-    highlightProductImages();
-  }
-
-  function textFromSelectors(selectors) {
-    for (const sel of selectors) {
-      const el = document.querySelector(sel);
-      if (el) {
-        const txt = el.textContent?.trim();
-        if (txt) return txt;
-      }
+  try {
+    const { isOnlineStore } = await import(
+      chrome.runtime.getURL('src/background/modules/urlUtils.js')
+    );
+    const currentUrl = new URL(window.location.href);
+    if (!(await isOnlineStore(currentUrl))) {
+      return;
     }
-    return '';
-  }
 
-  function collectColors() {
-    const elements = document.querySelectorAll(
-      '[itemprop="color"], [class*="color"] option, select[name*="color"] option, [data-color]'
-    );
-    const colors = [];
-    elements.forEach((el) => {
-      const val =
-        el.getAttribute('data-color') || el.textContent?.trim() || el.style.backgroundColor;
-      if (val && !colors.includes(val)) colors.push(val);
-    });
-    return colors;
-  }
-
-  function collectRecommended() {
-    const containers = document.querySelectorAll(
-      '.recommended-products, .similar-products, .related-products, [class*="recommended"], [class*="similar"], [class*="related"]'
-    );
-    const items = [];
-    containers.forEach((container) => {
-      container.querySelectorAll('a').forEach((a) => {
-        const img = a.querySelector('img');
-        if (!img || !img.src) return;
-        const name = img.getAttribute('alt') || a.textContent.trim();
-        items.push({ url: a.href || '', image: img.src, name });
+    function highlightProductImages() {
+      document.querySelectorAll('img').forEach((img) => {
+        if (img.naturalWidth > 100 && img.naturalHeight > 100) {
+          img.style.outline = '2px solid #ff6600';
+        }
       });
-    });
-    const unique = [];
-    const seen = new Set();
-    items.forEach((item) => {
-      const key = `${item.url}|${item.image}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        unique.push(item);
-      }
-    });
-    return unique;
-  }
+    }
 
-  function collectRatingValue() {
-    const el =
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', highlightProductImages);
+    } else {
+      highlightProductImages();
+    }
+
+    function textFromSelectors(selectors) {
+      for (const sel of selectors) {
+        const el = document.querySelector(sel);
+        if (el) {
+          const txt = el.textContent?.trim();
+          if (txt) return txt;
+        }
+      }
+      return '';
+    }
+
+    function collectColors() {
+      const elements = document.querySelectorAll(
+        '[itemprop="color"], [class*="color"] option, select[name*="color"] option, [data-color]'
+      );
+      const colors = [];
+      elements.forEach((el) => {
+        const val =
+        el.getAttribute('data-color') || el.textContent?.trim() || el.style.backgroundColor;
+        if (val && !colors.includes(val)) colors.push(val);
+      });
+      return colors;
+    }
+
+    function collectRecommended() {
+      const containers = document.querySelectorAll(
+        '.recommended-products, .similar-products, .related-products, [class*="recommended"], [class*="similar"], [class*="related"]'
+      );
+      const items = [];
+      containers.forEach((container) => {
+        container.querySelectorAll('a').forEach((a) => {
+          const img = a.querySelector('img');
+          if (!img || !img.src) return;
+          const name = img.getAttribute('alt') || a.textContent.trim();
+          items.push({ url: a.href || '', image: img.src, name });
+        });
+      });
+      const unique = [];
+      const seen = new Set();
+      items.forEach((item) => {
+        const key = `${item.url}|${item.image}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          unique.push(item);
+        }
+      });
+      return unique;
+    }
+
+    function collectRatingValue() {
+      const el =
       document.querySelector('[itemprop="ratingValue"]') ||
       document.querySelector('.rating');
-    if (!el) return '';
-    return (
-      el.getAttribute('content') || el.textContent?.match(/[\d.]+/)?.[0] || ''
-    );
-  }
+      if (!el) return '';
+      return (
+        el.getAttribute('content') || el.textContent?.match(/[\d.]+/)?.[0] || ''
+      );
+    }
 
-  function collectReviewSnippets() {
-    const snippets = [];
-    document
-      .querySelectorAll(
-        '[itemprop="review"] .review-text, .review-snippet, .review'
-      )
-      .forEach((el) => {
-        const txt = el.textContent?.trim();
-        if (txt) snippets.push(txt);
-      });
-    return snippets.slice(0, 3);
-  }
+    function collectReviewSnippets() {
+      const snippets = [];
+      document
+        .querySelectorAll(
+          '[itemprop="review"] .review-text, .review-snippet, .review'
+        )
+        .forEach((el) => {
+          const txt = el.textContent?.trim();
+          if (txt) snippets.push(txt);
+        });
+      return snippets.slice(0, 3);
+    }
 
-  function extractProductInfo() {
-    return {
-      name: textFromSelectors(['[itemprop="name"]', 'h1', 'meta[property="og:title"]']),
-      price: textFromSelectors(['[itemprop="price"]', '.price', '[class*="price"]']),
-      colors: collectColors(),
-      details: textFromSelectors([
-        '[itemprop="description"]',
-        '.product-description',
-        '[id*="description"]',
-      ]),
-      ratingValue: collectRatingValue(),
-      reviewSnippets: collectReviewSnippets(),
-      clothingType: textFromSelectors(['[itemprop="category"]']),
-      image:
+    function extractProductInfo() {
+      return {
+        name: textFromSelectors(['[itemprop="name"]', 'h1', 'meta[property="og:title"]']),
+        price: textFromSelectors(['[itemprop="price"]', '.price', '[class*="price"]']),
+        colors: collectColors(),
+        details: textFromSelectors([
+          '[itemprop="description"]',
+          '.product-description',
+          '[id*="description"]',
+        ]),
+        ratingValue: collectRatingValue(),
+        reviewSnippets: collectReviewSnippets(),
+        clothingType: textFromSelectors(['[itemprop="category"]']),
+        image:
         document.querySelector('[itemprop="image"]')?.src ||
         document.querySelector('meta[property="og:image"]')?.content ||
         document.querySelector('img')?.src ||
         '',
-      recommended: collectRecommended(),
-    };
-  }
-
-  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.action === 'getProductInfo') {
-      sendResponse(extractProductInfo());
+        recommended: collectRecommended(),
+      };
     }
-  });
+
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+      if (message.action === 'getProductInfo') {
+        sendResponse(extractProductInfo());
+      }
+    });
+  } catch (err) {
+    console.error('Content script failed', err);
+  }
 })();

--- a/src/popup/modules/tryOnService.js
+++ b/src/popup/modules/tryOnService.js
@@ -1,28 +1,9 @@
-import { TRY_ON_API_URL } from '../../shared/constants.js';
+// Currently returns a static placeholder image until the API is provided.
 
 // Send a request to the backend service to virtually "try on" a clothing item
 // identified by `clothingUrl` on the photo with id `photoId`.
 // Returns the URL of the processed image on success and throws on failure.
-export async function requestTryOn(photoId, clothingUrl, backendUrl = TRY_ON_API_URL) {
-  try {
-    const response = await fetch(backendUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ photoId, clothingUrl })
-    });
-
-    if (!response.ok) {
-      const text = await response.text().catch(() => '');
-      throw new Error(`Server error ${response.status}${text ? `: ${text}` : ''}`);
-    }
-
-    const data = await response.json();
-    if (!data || !data.imageUrl) {
-      throw new Error('Invalid response from server');
-    }
-    return data.imageUrl;
-  } catch (err) {
-    console.error('Try On request failed', err);
-    throw new Error(err.message || 'Failed to process try on');
-  }
+export async function requestTryOn() {
+  console.warn('Try On API not yet configured. Returning static image.');
+  return chrome.runtime.getURL('src/assets/images/models/clothing1.jpg');
 }


### PR DESCRIPTION
## Summary
- handle content script failures gracefully
- suppress messaging errors in the background service worker
- return a static image from `requestTryOn` until backend is ready
- document placeholder try-on behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a8aa32608832faa3d90975fc4127d