### PR TITLE
Fix product info loading

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -481,10 +481,18 @@ async function showPhotoDialog(clothingUrl) {
 
 function requestProductInfo() {
   return new Promise((resolve) => {
-    chrome.storage.local.get('lastActiveTabId', ({ lastActiveTabId }) => {
-      if (!lastActiveTabId) return resolve(null);
-      chrome.tabs.sendMessage(lastActiveTabId, { action: 'getProductInfo' }, (res) => {
-        resolve(res);
+    chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+      if (chrome.runtime.lastError || !tabs || !tabs.length) {
+        resolve(null);
+        return;
+      }
+      const tabId = tabs[0].id;
+      chrome.tabs.sendMessage(tabId, { action: 'getProductInfo' }, (res) => {
+        if (chrome.runtime.lastError) {
+          resolve(null);
+        } else {
+          resolve(res);
+        }
       });
     });
   });


### PR DESCRIPTION
## Summary
- query the active tab to fetch product details instead of relying on stored tab id

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a946ab3d4832f91e2e6ae9c6467ec