### PR TITLE
Improve home tab layout and default visibility

### DIFF
--- a/src/popup/partials/home.html
+++ b/src/popup/partials/home.html
@@ -1,3 +1,32 @@
 <div id="home" class="tab-content">
-  <p>Welcome to the home tab.</p>
+  <div class="home-intro">
+    <p>
+      Imagine helps you discover fashion stores, extract product details and try
+      outfits virtually. Use the tabs above to explore each feature.
+    </p>
+  </div>
+  <div class="home-features">
+    <div class="feature-item">
+      <i class="fas fa-store"></i>
+      <span>Browse curated stores</span>
+    </div>
+    <div class="feature-item">
+      <i class="fas fa-box-open"></i>
+      <span>View product information</span>
+    </div>
+    <div class="feature-item">
+      <i class="fas fa-tshirt"></i>
+      <span>Try items in the dressing room</span>
+    </div>
+    <div class="feature-item">
+      <i class="fas fa-heart"></i>
+      <span>Save favourites to your wishlist</span>
+    </div>
+  </div>
+  <div class="home-actions">
+    <button id="open-options" class="btn btn-primary btn-rounded">Options</button>
+    <button class="centralized-wishlist-btn btn btn-secondary btn-rounded">
+      Wishlist
+    </button>
+  </div>
 </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="styles/dressing-room.css" />
     <link rel="stylesheet" href="styles/misc.css" />
     <link rel="stylesheet" href="styles/wishlist.css" />
+    <link rel="stylesheet" href="styles/home.css" />
     <link rel="stylesheet" href="styles/tabs.css" />
     <link
       rel="stylesheet"
@@ -165,7 +166,41 @@
         </div>
         <!-- Home Tab Content -->
         <div id="home" class="tab-content">
-          <p>Welcome to the home tab.</p>
+          <div class="home-intro">
+            <p>
+              Imagine helps you discover fashion stores, extract product details
+              and try outfits virtually. Use the tabs above to explore each
+              feature.
+            </p>
+          </div>
+          <div class="home-features">
+            <div class="feature-item">
+              <i class="fas fa-store"></i>
+              <span>Browse curated stores</span>
+            </div>
+            <div class="feature-item">
+              <i class="fas fa-box-open"></i>
+              <span>View product information</span>
+            </div>
+            <div class="feature-item">
+              <i class="fas fa-tshirt"></i>
+              <span>Try items in the dressing room</span>
+            </div>
+            <div class="feature-item">
+              <i class="fas fa-heart"></i>
+              <span>Save favourites to your wishlist</span>
+            </div>
+          </div>
+          <div class="home-actions">
+            <button id="open-options" class="btn btn-primary btn-rounded">
+              Options
+            </button>
+            <button
+              class="centralized-wishlist-btn btn btn-secondary btn-rounded"
+            >
+              Wishlist
+            </button>
+          </div>
         </div>
 
         <!-- Wishlist Tab Content -->

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -89,7 +89,12 @@ function initializeTabSwitching() {
     });
   }
 
-  document.getElementById('store-discovery-tab').click();
+  chrome.storage.local.get('homeSeen', ({ homeSeen }) => {
+    const defaultId = homeSeen ? 'store-discovery-tab' : 'home-tab';
+    const btn = document.getElementById(defaultId);
+    if (btn) btn.click();
+    if (!homeSeen) chrome.storage.local.set({ homeSeen: true });
+  });
 }
 
 async function initializeApp() {
@@ -127,6 +132,7 @@ function setupEventListeners(elements, state) {
   setupAvatarToggle();
   setupModelGridControls();
   setupCentralizedWishlistNavigation();
+  setupHomeNavigation();
   setupPhotoUpload();
 }
 
@@ -334,6 +340,17 @@ function setupCentralizedWishlistNavigation() {
       window.open(url, '_blank');
     }
   });
+}
+
+function setupHomeNavigation() {
+  const optionsBtn = document.getElementById('open-options');
+  if (optionsBtn) {
+    optionsBtn.addEventListener('click', () => {
+      if (chrome.runtime && chrome.runtime.openOptionsPage) {
+        chrome.runtime.openOptionsPage();
+      }
+    });
+  }
 }
 
 async function loadAndRenderPhotos() {

--- a/src/popup/styles/home.css
+++ b/src/popup/styles/home.css
@@ -1,0 +1,37 @@
+.home-intro {
+  margin-bottom: var(--spacing-lg);
+}
+
+.home-features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+}
+
+.feature-item {
+  background-color: var(--color-card);
+  padding: var(--spacing-md) var(--spacing-sm);
+  border-radius: var(--radius-md);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.feature-item i {
+  font-size: 24px;
+  margin-bottom: var(--spacing-sm);
+  color: var(--color-primary);
+}
+
+.feature-item span {
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.home-actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-md);
+}


### PR DESCRIPTION
## Summary
- add new structured home tab layout with features and action buttons
- style the home tab via new `home.css`
- import the new CSS in the popup
- open the home tab on first run and wire buttons to options and wishlist

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686a96554518832fbdf5b09d520f120b