### PR TITLE
Enable try-on button

### DIFF
--- a/src/popup/partials/product-discovery.html
+++ b/src/popup/partials/product-discovery.html
@@ -16,7 +16,7 @@
   <p class="product-placeholder" style="display: none">No product detected on this page.</p>
 
   <div class="try-on-button">
-    <button class="btn btn-primary btn-rounded">Try On</button>
+    <button class="btn btn-primary btn-rounded" title="Open the virtual try-on dialog">Open Try-On</button>
   </div>
 
   <div class="product-colors-section">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -85,7 +85,7 @@
 
           <!-- Try On Button (Centered) -->
           <div class="try-on-button">
-            <button class="btn btn-primary btn-rounded">Add to dressing room</button>
+            <button class="btn btn-primary btn-rounded" title="Open the virtual try-on dialog">Open Try-On</button>
           </div>
 
           <!-- Product Colors Section (Larger Swatches) -->

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -128,6 +128,7 @@ function setupEventListeners(elements, state) {
   setupModelGridControls();
   setupCentralizedWishlistNavigation();
   setupPhotoUpload();
+  setupTryOnButton();
 }
 
 function setupSearchListener({ searchBar, loadMoreButton, storeGrid }, state) {
@@ -372,6 +373,19 @@ function setupPhotoUpload() {
       }
     };
     reader.readAsDataURL(file);
+  });
+}
+
+function setupTryOnButton() {
+  const container = document.querySelector('.try-on-button');
+  const btn = container?.querySelector('button');
+  if (!btn) return;
+  btn.textContent = 'Open Try-On';
+  btn.title = 'Open the virtual try-on dialog';
+  btn.addEventListener('click', () => {
+    const img = document.querySelector('.product-image');
+    const url = img?.src;
+    if (url) showPhotoDialog(url);
   });
 }
 


### PR DESCRIPTION
## Summary
- wire up try-on button in product discovery tab
- clarify try-on button text

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a97c08368832fbdae9857c054f757