### PR TITLE
Improve wishlist management

### DIFF
--- a/src/popup/modules/wishlist.js
+++ b/src/popup/modules/wishlist.js
@@ -56,9 +56,16 @@ export async function removeFromWishlist(identifier) {
 
 export async function renderWishlist(container) {
   try {
-    const items = await getWishlist();
+    let items = await getWishlist();
     if (!container) return;
     container.innerHTML = '';
+    if (!items.length) {
+      container.textContent = 'Your wishlist is empty.';
+      return;
+    }
+    items = items.sort(
+      (a, b) => new Date(b.dateAdded) - new Date(a.dateAdded),
+    );
     items.forEach((item) => {
       const div = document.createElement('div');
       div.className = 'wishlist-item card';

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -206,6 +206,7 @@
         <!-- Wishlist Tab Content -->
         <div id="wishlist" class="tab-content">
           <button class="centralized-wishlist-btn btn btn-primary btn-rounded">Go to Centralized Wishlist</button>
+          <button id="clear-wishlist-btn" class="clear-wishlist-btn btn btn-error btn-rounded">Clear All</button>
           <h3>Your Wishlist</h3>
           <div id="wishlist-grid" class="wishlist-grid"></div>
         </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -7,6 +7,7 @@ import {
   renderWishlist,
   isInWishlist,
   removeFromWishlist,
+  saveWishlist,
 } from './modules/wishlist.js';
 import {
   getPhotos,
@@ -132,6 +133,7 @@ function setupEventListeners(elements, state) {
   setupAvatarToggle();
   setupModelGridControls();
   setupCentralizedWishlistNavigation();
+  setupClearWishlistButton();
   setupHomeNavigation();
   setupPhotoUpload();
   setupTryOnButton();
@@ -340,6 +342,16 @@ function setupCentralizedWishlistNavigation() {
     } else {
       window.open(url, '_blank');
     }
+  });
+}
+
+function setupClearWishlistButton() {
+  const btn = document.getElementById('clear-wishlist-btn');
+  if (!btn) return;
+  btn.addEventListener('click', async () => {
+    await saveWishlist([]);
+    const grid = document.getElementById('wishlist-grid');
+    renderWishlist(grid);
   });
 }
 

--- a/src/popup/styles/wishlist.css
+++ b/src/popup/styles/wishlist.css
@@ -19,6 +19,26 @@
   transform: scale(1.05);
 }
 
+/* Clear Wishlist Button */
+.clear-wishlist-btn {
+  display: block;
+  width: 100%;
+  margin: 10px 0 20px;
+  padding: 10px;
+  background-color: var(--color-error);
+  color: var(--color-card);
+  border: none;
+  border-radius: 8px;
+  text-align: center;
+  cursor: pointer;
+  transition: background-color 0.3s, transform 0.2s;
+}
+
+.clear-wishlist-btn:hover {
+  background-color: var(--color-error);
+  transform: scale(1.05);
+}
+
 /* Wishlist Category */
 .wishlist-category {
   margin-top: 40px;


### PR DESCRIPTION
## Summary
- show a friendly empty state when no wishlist items are stored
- add a **Clear All** button on the wishlist tab
- sort wishlist items by date added
- style the new clear button

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686a97ea4a60832f92942d4a94c3278c