### PR TITLE
Add caching for store data

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs && node test/wishlist.test.mjs",
+    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs && node test/wishlist.test.mjs && node test/storeService.test.mjs",
     "lint": "eslint src test"
   },
   "keywords": [],

--- a/src/popup/modules/storeService.js
+++ b/src/popup/modules/storeService.js
@@ -1,12 +1,22 @@
 import { STORES_DATA_PATH } from "../../shared/constants.js";
 
+let cachedStores;
+
+export function clearStoreCache() {
+  cachedStores = undefined;
+}
+
 export async function loadStores(dataUrl = STORES_DATA_PATH) {
+  if (cachedStores) {
+    return cachedStores;
+  }
   try {
     const response = await fetch(chrome.runtime.getURL(dataUrl));
     if (!response.ok) {
       throw new Error(`Failed to fetch ${dataUrl}: ${response.status}`);
     }
-    return await response.json();
+    cachedStores = await response.json();
+    return cachedStores;
   } catch (error) {
     console.error('Error loading stores:', error);
     if (error instanceof TypeError) {

--- a/test/storeService.test.mjs
+++ b/test/storeService.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+import fs from 'node:fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+let fetchCount = 0;
+
+global.chrome = {
+  runtime: {
+    getURL: (p) => pathToFileURL(join(__dirname, '..', p)).href,
+  },
+};
+
+global.fetch = async (url) => {
+  fetchCount++;
+  if (url.startsWith('file://')) {
+    const data = await fs.readFile(new URL(url), 'utf8');
+    return { ok: true, json: async () => JSON.parse(data) };
+  }
+  throw new Error('Unsupported protocol in test fetch');
+};
+
+import { loadStores, clearStoreCache } from '../src/popup/modules/storeService.js';
+
+async function runTests() {
+  clearStoreCache();
+  fetchCount = 0;
+  const stores1 = await loadStores('src/assets/data/stores.json');
+  assert.ok(Array.isArray(stores1) && stores1.length > 0, 'loaded stores');
+  assert.equal(fetchCount, 1, 'fetch called first time');
+
+  const stores2 = await loadStores('src/assets/data/stores.json');
+  assert.equal(fetchCount, 1, 'cache used on second call');
+  assert.strictEqual(stores1, stores2, 'same cached array');
+
+  clearStoreCache();
+  const stores3 = await loadStores('src/assets/data/stores.json');
+  assert.equal(fetchCount, 2, 'fetch called after clearing cache');
+  assert.ok(Array.isArray(stores3), 'stores loaded again');
+
+  console.log('All tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- cache store data in memory
- allow tests to flush cache
- add tests for storeService caching

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a995f19d8832fa52d2e788c87defa