### PR TITLE
Add wishlist UI improvements

### DIFF
--- a/src/popup/centralized-wishlist.html
+++ b/src/popup/centralized-wishlist.html
@@ -7,11 +7,25 @@
     <link rel="stylesheet" href="styles/base.css" />
     <link rel="stylesheet" href="styles/general.css" />
     <link rel="stylesheet" href="styles/wishlist.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+    />
   </head>
   <body class="theme-light">
     <div class="container">
       <h1>Centralized Wishlist</h1>
       <p class="instructions">Use the buttons below each item to visit the original product page.</p>
+      <div class="wishlist-controls">
+        <input id="wishlist-search" type="text" placeholder="Search wishlist..." />
+        <select id="wishlist-sort">
+          <option value="date-desc">Newest</option>
+          <option value="date-asc">Oldest</option>
+          <option value="price-asc">Price: Low to High</option>
+          <option value="price-desc">Price: High to Low</option>
+        </select>
+        <button id="clear-wishlist-btn" class="clear-wishlist-btn btn btn-error btn-rounded">Clear All</button>
+      </div>
       <div id="wishlist-grid" class="wishlist-grid"></div>
     </div>
     <script type="module" src="centralized-wishlist.js"></script>

--- a/src/popup/centralized-wishlist.js
+++ b/src/popup/centralized-wishlist.js
@@ -1,4 +1,10 @@
-import { renderWishlist } from './modules/wishlist.js';
+import {
+  renderWishlist,
+  getWishlist,
+  saveWishlist,
+  filterWishlist,
+  sortWishlist,
+} from './modules/wishlist.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   chrome.storage.sync.get('theme', ({ theme }) => {
@@ -6,15 +12,40 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.classList.add(theme === 'dark' ? 'theme-dark' : 'theme-light');
   });
 
-  chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === 'sync' && changes.theme) {
-      const theme = changes.theme.newValue;
-      document.body.classList.remove('theme-dark', 'theme-light');
-      document.body.classList.add(
-        theme === 'dark' ? 'theme-dark' : 'theme-light'
-      );
+  const search = document.getElementById('wishlist-search');
+  const sort = document.getElementById('wishlist-sort');
+  const clearBtn = document.getElementById('clear-wishlist-btn');
+  const container = document.getElementById('wishlist-grid');
+
+  async function updateList() {
+    let items = await getWishlist();
+    items = filterWishlist(items, search.value);
+    items = sortWishlist(items, sort.value);
+    renderWishlist(container, items);
+  }
+
+  search.addEventListener('input', updateList);
+  sort.addEventListener('change', updateList);
+  clearBtn.addEventListener('click', async () => {
+    if (confirm('Clear all wishlist items?')) {
+      await saveWishlist([]);
     }
   });
-  const container = document.getElementById('wishlist-grid');
-  renderWishlist(container);
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'sync') {
+      if (changes.theme) {
+        const theme = changes.theme.newValue;
+        document.body.classList.remove('theme-dark', 'theme-light');
+        document.body.classList.add(
+          theme === 'dark' ? 'theme-dark' : 'theme-light'
+        );
+      }
+      if (changes.wishlist) {
+        updateList();
+      }
+    }
+  });
+
+  updateList();
 });

--- a/src/popup/modules/wishlist.js
+++ b/src/popup/modules/wishlist.js
@@ -54,18 +54,50 @@ export async function removeFromWishlist(identifier) {
   }
 }
 
-export async function renderWishlist(container) {
+export function filterWishlist(items, term = '') {
+  const t = term.toLowerCase();
+  return items.filter(
+    (i) =>
+      i.name.toLowerCase().includes(t) ||
+      (i.storeName && i.storeName.toLowerCase().includes(t)),
+  );
+}
+
+function parsePrice(p) {
+  const num = parseFloat(p?.replace(/[^0-9.]+/g, ''));
+  return Number.isNaN(num) ? Infinity : num;
+}
+
+export function sortWishlist(items, sort = 'date-desc') {
+  const sorted = [...items];
+  sorted.sort((a, b) => {
+    switch (sort) {
+    case 'price-asc':
+      return parsePrice(a.price) - parsePrice(b.price);
+    case 'price-desc':
+      return parsePrice(b.price) - parsePrice(a.price);
+    case 'date-asc':
+      return new Date(a.dateAdded) - new Date(b.dateAdded);
+    case 'date-desc':
+    default:
+      return new Date(b.dateAdded) - new Date(a.dateAdded);
+    }
+  });
+  return sorted;
+}
+
+export async function renderWishlist(container, items = null) {
   try {
-    let items = await getWishlist();
+    if (!items) {
+      items = await getWishlist();
+    }
     if (!container) return;
     container.innerHTML = '';
     if (!items.length) {
       container.textContent = 'Your wishlist is empty.';
       return;
     }
-    items = items.sort(
-      (a, b) => new Date(b.dateAdded) - new Date(a.dateAdded),
-    );
+    items = sortWishlist(items);
     items.forEach((item) => {
       const div = document.createElement('div');
       div.className = 'wishlist-item card';
@@ -74,6 +106,7 @@ export async function renderWishlist(container) {
         ? item.imageSrc
         : chrome.runtime.getURL(item.imageSrc);
       img.alt = item.name;
+      img.loading = 'lazy';
       div.appendChild(img);
 
       const nameP = document.createElement('p');
@@ -82,7 +115,18 @@ export async function renderWishlist(container) {
 
       if (item.storeName) {
         const storeP = document.createElement('p');
-        storeP.textContent = item.storeName;
+        if (item.url) {
+          const fav = document.createElement('img');
+          fav.className = 'store-favicon';
+          fav.alt = '';
+          try {
+            fav.src = `https://www.google.com/s2/favicons?domain=${new URL(item.url).hostname}`;
+          } catch {
+            /* ignore */
+          }
+          storeP.appendChild(fav);
+        }
+        storeP.appendChild(document.createTextNode(item.storeName));
         div.appendChild(storeP);
       }
 
@@ -130,7 +174,7 @@ export async function renderWishlist(container) {
 
       const removeBtn = document.createElement('button');
       removeBtn.className = 'remove-btn btn btn-error btn-rounded';
-      removeBtn.textContent = 'Remove';
+      removeBtn.innerHTML = '<i class="fas fa-trash"></i>';
       removeBtn.addEventListener('click', async () => {
         await removeFromWishlist(item.dateAdded);
         renderWishlist(container);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -28,12 +28,18 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === 'sync' && changes.theme) {
-      const theme = changes.theme.newValue;
-      document.body.classList.remove('theme-dark', 'theme-light');
-      document.body.classList.add(
-        theme === 'dark' ? 'theme-dark' : 'theme-light'
-      );
+    if (area === 'sync') {
+      if (changes.theme) {
+        const theme = changes.theme.newValue;
+        document.body.classList.remove('theme-dark', 'theme-light');
+        document.body.classList.add(
+          theme === 'dark' ? 'theme-dark' : 'theme-light'
+        );
+      }
+      if (changes.wishlist) {
+        const grid = document.getElementById('wishlist-grid');
+        if (grid) renderWishlist(grid);
+      }
     }
   });
 
@@ -349,9 +355,11 @@ function setupClearWishlistButton() {
   const btn = document.getElementById('clear-wishlist-btn');
   if (!btn) return;
   btn.addEventListener('click', async () => {
-    await saveWishlist([]);
-    const grid = document.getElementById('wishlist-grid');
-    renderWishlist(grid);
+    if (confirm('Clear all wishlist items?')) {
+      await saveWishlist([]);
+      const grid = document.getElementById('wishlist-grid');
+      renderWishlist(grid);
+    }
   });
 }
 

--- a/src/popup/styles/wishlist.css
+++ b/src/popup/styles/wishlist.css
@@ -134,3 +134,29 @@
   background-color: var(--color-error);
   transform: scale(1.05);
 }
+
+.store-favicon {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+.wishlist-controls {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+#wishlist-search {
+  flex: 1;
+  padding: 6px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+#wishlist-sort {
+  padding: 6px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}


### PR DESCRIPTION
## Summary
- show a search bar and sort dropdown for the centralized wishlist
- implement storage-driven updates and clear confirmation
- support search/sort helpers in wishlist module
- lazy-load wishlist images, add store favicons, and show trash icon
- style wishlist controls

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686aa9efdb28832fa003c5b3cc04d059