### PR TITLE
Improve home landing page

### DIFF
--- a/src/popup/partials/home.html
+++ b/src/popup/partials/home.html
@@ -7,25 +7,57 @@
   </div>
   <div class="home-features">
     <div class="feature-item">
-      <i class="fas fa-store"></i>
-      <span>Browse curated stores</span>
+      <div class="icon-wrapper">
+        <i class="fas fa-store"></i>
+      </div>
+      <h3>Store Finder</h3>
+      <p>Browse curated stores</p>
+      <span class="cta-chip">Browse</span>
     </div>
     <div class="feature-item">
-      <i class="fas fa-box-open"></i>
-      <span>View product information</span>
+      <div class="icon-wrapper">
+        <i class="fas fa-box-open"></i>
+      </div>
+      <h3>Product Info</h3>
+      <p>Get detailed information</p>
+      <span class="cta-chip">View</span>
     </div>
     <div class="feature-item">
-      <i class="fas fa-tshirt"></i>
-      <span>Try items in the dressing room</span>
+      <div class="icon-wrapper">
+        <i class="fas fa-tshirt"></i>
+      </div>
+      <h3>Dressing Room</h3>
+      <p>Try outfits virtually</p>
+      <span class="cta-chip">Try Now</span>
     </div>
     <div class="feature-item">
-      <i class="fas fa-heart"></i>
-      <span>Save favourites to your wishlist</span>
+      <div class="icon-wrapper">
+        <i class="fas fa-heart"></i>
+      </div>
+      <h3>Wishlist</h3>
+      <p>Save favourites easily</p>
+      <span class="cta-chip">Save</span>
+    </div>
+    <div class="feature-item">
+      <div class="icon-wrapper">
+        <i class="fas fa-filter"></i>
+      </div>
+      <h3>Smart Filters</h3>
+      <p>Narrow results quickly</p>
+      <span class="cta-chip">Filter</span>
+    </div>
+    <div class="feature-item">
+      <div class="icon-wrapper">
+        <i class="fas fa-cog"></i>
+      </div>
+      <h3>Settings</h3>
+      <p>Customize your experience</p>
+      <span class="cta-chip">Setup</span>
     </div>
   </div>
   <div class="home-actions">
-    <button id="open-options" class="btn btn-primary btn-rounded">Options</button>
-    <button class="centralized-wishlist-btn btn btn-secondary btn-rounded">
+    <button id="open-options" class="btn btn-primary btn-rounded btn-large">Options</button>
+    <button class="centralized-wishlist-btn btn btn-secondary btn-rounded btn-large">
       Wishlist
     </button>
   </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -175,28 +175,60 @@
           </div>
           <div class="home-features">
             <div class="feature-item">
-              <i class="fas fa-store"></i>
-              <span>Browse curated stores</span>
+              <div class="icon-wrapper">
+                <i class="fas fa-store"></i>
+              </div>
+              <h3>Store Finder</h3>
+              <p>Browse curated stores</p>
+              <span class="cta-chip">Browse</span>
             </div>
             <div class="feature-item">
-              <i class="fas fa-box-open"></i>
-              <span>View product information</span>
+              <div class="icon-wrapper">
+                <i class="fas fa-box-open"></i>
+              </div>
+              <h3>Product Info</h3>
+              <p>Get detailed information</p>
+              <span class="cta-chip">View</span>
             </div>
             <div class="feature-item">
-              <i class="fas fa-tshirt"></i>
-              <span>Try items in the dressing room</span>
+              <div class="icon-wrapper">
+                <i class="fas fa-tshirt"></i>
+              </div>
+              <h3>Dressing Room</h3>
+              <p>Try outfits virtually</p>
+              <span class="cta-chip">Try Now</span>
             </div>
             <div class="feature-item">
-              <i class="fas fa-heart"></i>
-              <span>Save favourites to your wishlist</span>
+              <div class="icon-wrapper">
+                <i class="fas fa-heart"></i>
+              </div>
+              <h3>Wishlist</h3>
+              <p>Save favourites easily</p>
+              <span class="cta-chip">Save</span>
+            </div>
+            <div class="feature-item">
+              <div class="icon-wrapper">
+                <i class="fas fa-filter"></i>
+              </div>
+              <h3>Smart Filters</h3>
+              <p>Narrow results quickly</p>
+              <span class="cta-chip">Filter</span>
+            </div>
+            <div class="feature-item">
+              <div class="icon-wrapper">
+                <i class="fas fa-cog"></i>
+              </div>
+              <h3>Settings</h3>
+              <p>Customize your experience</p>
+              <span class="cta-chip">Setup</span>
             </div>
           </div>
           <div class="home-actions">
-            <button id="open-options" class="btn btn-primary btn-rounded">
+            <button id="open-options" class="btn btn-primary btn-rounded btn-large">
               Options
             </button>
             <button
-              class="centralized-wishlist-btn btn btn-secondary btn-rounded"
+              class="centralized-wishlist-btn btn btn-secondary btn-rounded btn-large"
             >
               Wishlist
             </button>

--- a/src/popup/styles/home.css
+++ b/src/popup/styles/home.css
@@ -4,34 +4,108 @@
 
 .home-features {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--spacing-md);
   margin-bottom: var(--spacing-lg);
 }
 
+@media (min-width: 768px) {
+  .home-features {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
 .feature-item {
   background-color: var(--color-card);
-  padding: var(--spacing-md) var(--spacing-sm);
+  padding: var(--spacing-lg) var(--spacing-md);
   border-radius: var(--radius-md);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.icon-wrapper {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto var(--spacing-sm);
+  border-radius: 50%;
   display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 123, 255, 0.1);
 }
 
-.feature-item i {
-  font-size: 24px;
-  margin-bottom: var(--spacing-sm);
+body.theme-dark .icon-wrapper {
+  background-color: rgba(74, 144, 226, 0.1);
+}
+
+.icon-wrapper i {
   color: var(--color-primary);
+  font-size: 24px;
 }
 
-.feature-item span {
-  font-size: 14px;
+.feature-item h3 {
+  margin: 0 0 var(--spacing-xs);
+  font-size: 16px;
   color: var(--color-text);
+}
+
+.feature-item p {
+  margin: 0 0 var(--spacing-sm);
+  font-size: 14px;
+  color: var(--color-muted);
+}
+
+.cta-chip {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background-color: var(--color-primary);
+  color: var(--color-card);
+  font-size: 12px;
 }
 
 .home-actions {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   gap: var(--spacing-md);
+}
+
+@media (min-width: 500px) {
+  .home-actions {
+    flex-direction: row;
+  }
+}
+
+.home-actions .btn-large {
+  font-size: 18px;
+  padding: var(--spacing-md);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  position: relative;
+  overflow: hidden;
+}
+
+.home-actions .btn-large::after {
+  content: '';
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.home-actions .btn-large:active::after {
+  animation: ripple 0.6s linear;
+}
+
+@keyframes ripple {
+  to {
+    transform: translate(-50%, -50%) scale(4);
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign landing page with feature grid and CTA chips
- rework layout to show 2x2 grid on phones and 3x2 on larger screens
- add large Options and Wishlist buttons with ripple effect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aab63b43c832f9c003cdae8663a59