### PR TITLE
Fix jest script and ignore coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ yarn-error.log*
 dist/
 build/
 
+# Test coverage output
+coverage/
+
 # OS metadata
 .DS_Store
 Thumbs.db

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs && node test/wishlist.test.mjs && node test/storeService.test.mjs && jest",
+    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs && node test/wishlist.test.mjs && node test/storeService.test.mjs && npx jest",
     "lint": "eslint src test"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- ensure the test script invokes Jest via `npx`
- ignore coverage directory output

## Testing
- `npm run test -- --watchAll=false --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686ab68dd160832fa04b2f2f1e1297e0