### PR TITLE
Fix insecure endpoint

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -30,6 +30,12 @@ select {
   margin-bottom: 20px;
 }
 
+input[type="text"] {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
 button {
   padding: 10px 20px;
   background-color: var(--color-primary);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -15,6 +15,8 @@
         <option value="light">Light</option>
         <option value="dark">Dark</option>
       </select>
+      <label for="api-endpoint">Try On API Endpoint:</label>
+      <input type="text" id="api-endpoint" placeholder="https://example.com/api/try-on" />
       <button id="save-settings">Save</button>
       <div id="status-message" class="status-message"></div>
     </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const themeSelect = document.getElementById('theme');
+  const apiInput = document.getElementById('api-endpoint');
   const statusMessage = document.getElementById('status-message');
 
   const showMessage = (message, isError = false) => {
@@ -13,22 +14,30 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 3000);
   };
 
-  chrome.storage.sync.get('theme', ({ theme }) => {
+  chrome.storage.sync.get(['theme', 'apiEndpoint'], ({ theme, apiEndpoint }) => {
     if (theme) {
       themeSelect.value = theme;
+    }
+    if (apiInput && apiEndpoint) {
+      apiInput.value = apiEndpoint;
     }
     document.body.classList.remove('theme-dark', 'theme-light');
     document.body.classList.add(theme === 'dark' ? 'theme-dark' : 'theme-light');
   });
 
   chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === 'sync' && changes.theme) {
-      const theme = changes.theme.newValue;
-      if (themeSelect) themeSelect.value = theme;
-      document.body.classList.remove('theme-dark', 'theme-light');
-      document.body.classList.add(
-        theme === 'dark' ? 'theme-dark' : 'theme-light'
-      );
+    if (area === 'sync') {
+      if (changes.theme) {
+        const theme = changes.theme.newValue;
+        if (themeSelect) themeSelect.value = theme;
+        document.body.classList.remove('theme-dark', 'theme-light');
+        document.body.classList.add(
+          theme === 'dark' ? 'theme-dark' : 'theme-light'
+        );
+      }
+      if (changes.apiEndpoint && apiInput) {
+        apiInput.value = changes.apiEndpoint.newValue;
+      }
     }
   });
 
@@ -36,7 +45,8 @@ document.addEventListener('DOMContentLoaded', () => {
     .getElementById('save-settings')
     .addEventListener('click', () => {
       const theme = themeSelect.value;
-      chrome.storage.sync.set({ theme: theme }, () => {
+      const apiEndpoint = apiInput ? apiInput.value.trim() : '';
+      chrome.storage.sync.set({ theme: theme, apiEndpoint }, () => {
         if (chrome.runtime.lastError) {
           showMessage('Failed to save settings. Please try again.', true);
         } else {

--- a/src/popup/modules/tryOnService.js
+++ b/src/popup/modules/tryOnService.js
@@ -1,9 +1,38 @@
-// Currently returns a static placeholder image until the API is provided.
+import { TRY_ON_API_URL } from '../../shared/constants.js';
+
+async function getStoredApiUrl() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get('apiEndpoint', ({ apiEndpoint }) => {
+      if (chrome.runtime.lastError) {
+        resolve(undefined);
+      } else {
+        resolve(apiEndpoint);
+      }
+    });
+  });
+}
 
 // Send a request to the backend service to virtually "try on" a clothing item
-// identified by `clothingUrl` on the photo with id `photoId`.
-// Returns the URL of the processed image on success and throws on failure.
-export async function requestTryOn() {
-  console.warn('Try On API not yet configured. Returning static image.');
-  return chrome.runtime.getURL('src/assets/images/models/clothing1.jpg');
+// identified by `clothingUrl` on the photo with id `photoId`. Consumers can
+// override the API URL by passing `options.apiUrl` or setting the value in the
+// Options page. Returns the URL of the processed image on success and throws on
+// failure. If the request fails, a placeholder image is returned.
+export async function requestTryOn(photoId, clothingUrl, options = {}) {
+  const storedUrl = await getStoredApiUrl();
+  const apiUrl = options.apiUrl || storedUrl || TRY_ON_API_URL;
+  try {
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ photoId, clothingUrl }),
+    });
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`);
+    }
+    const data = await response.json();
+    return data.imageUrl;
+  } catch (err) {
+    console.warn('Try On API request failed, using placeholder image.', err);
+    return chrome.runtime.getURL('src/assets/images/models/clothing1.jpg');
+  }
 }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -3,4 +3,6 @@ export const STORES_DATA_PATH = 'src/assets/data/stores.json';
 // Base URL for the backend that processes "try on" requests.  Consumers can
 // override this via chrome.storage or by passing a different URL to the
 // requestTryOn function.
-export const TRY_ON_API_URL = 'http://localhost:3000/api/try-on';
+// Default HTTPS endpoint for the try on API. The value can be overridden in the
+// extension's Options page via the `apiEndpoint` setting.
+export const TRY_ON_API_URL = 'https://localhost:3000/api/try-on';


### PR DESCRIPTION
## Summary
- update TRY_ON_API_URL to use https by default
- add API endpoint input to options page
- persist apiEndpoint in options.js
- load API URL from storage and call it in tryOnService

## Testing
- `npm test` *(fails: needs jest package)*

------
https://chatgpt.com/codex/tasks/task_e_686ab90822ec832f95fc8b309ca7e526