### PR TITLE
Add ARIA labels for popup tabs

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -23,24 +23,36 @@
     <div class="container">
       <h1>Imagine Assistant</h1>
       <div class="tabs">
-        <button class="tab-button active" id="store-discovery-tab">
+        <button
+          class="tab-button active"
+          id="store-discovery-tab"
+          aria-label="Store Discovery"
+        >
           <i class="fas fa-store"></i>
         </button>
-        <button class="tab-button" id="product-discovery-tab">
+        <button
+          class="tab-button"
+          id="product-discovery-tab"
+          aria-label="Product Discovery"
+        >
           <i class="fas fa-box-open"></i>
         </button>
-        <button class="tab-button" id="dressing-room-tab">
+        <button
+          class="tab-button"
+          id="dressing-room-tab"
+          aria-label="Dressing Room"
+        >
           <i class="fas fa-tshirt"></i>
         </button>
-          <button class="tab-button" id="wishlist-tab">
-            <i class="fas fa-heart"></i>
-          </button>
-          <button class="tab-button" id="home-tab">
-            <i class="fas fa-home"></i>
-          </button>
-          <button class="tab-button" id="options-button">
-            <i class="fas fa-cog"></i>
-          </button>
+        <button class="tab-button" id="wishlist-tab" aria-label="Wishlist">
+          <i class="fas fa-heart"></i>
+        </button>
+        <button class="tab-button" id="home-tab" aria-label="Home">
+          <i class="fas fa-home"></i>
+        </button>
+        <button class="tab-button" id="options-button" aria-label="Options">
+          <i class="fas fa-cog"></i>
+        </button>
         </div>
 
       <div id="tab-content">


### PR DESCRIPTION
## Summary
- improve accessibility in `popup.html` by adding `aria-label` attributes to each tab button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686abaf0712c832f9933a470adf0577d