### PR TITLE
Validate sender for product detection messages

### DIFF
--- a/src/background/onProductDetected.js
+++ b/src/background/onProductDetected.js
@@ -6,7 +6,10 @@ export async function onProductDetected(product, similars) {
 }
 
 export function registerProductListener() {
-  chrome.runtime.onMessage.addListener((msg) => {
+  chrome.runtime.onMessage.addListener((msg, sender) => {
+    if (sender.id !== chrome.runtime.id) {
+      return;
+    }
     if (msg && msg.type === 'productDetected') {
       void onProductDetected(msg.product, msg.similars);
     }

--- a/src/background/onProductDetected.ts
+++ b/src/background/onProductDetected.ts
@@ -14,7 +14,10 @@ export async function onProductDetected(product: Product | null, similars: Simil
  * Register message listener for product detection events.
  */
 export function registerProductListener() {
-  chrome.runtime.onMessage.addListener((msg) => {
+  chrome.runtime.onMessage.addListener((msg, sender) => {
+    if (sender.id !== chrome.runtime.id) {
+      return;
+    }
     if (msg && msg.type === 'productDetected') {
       void onProductDetected(msg.product, msg.similars);
     }


### PR DESCRIPTION
## Summary
- validate message sender in `onProductDetected` to ensure messages originate from this extension

## Testing
- `npm test` *(fails: needs jest install)*

------
https://chatgpt.com/codex/tasks/task_e_686ab8e81c58832f8c5c0e3ed4b176ba