### PR TITLE
Fix wishlist quota handling

### DIFF
--- a/src/popup/modules/wishlist.js
+++ b/src/popup/modules/wishlist.js
@@ -14,15 +14,26 @@ export async function getWishlist() {
 }
 
 export async function saveWishlist(items) {
-  return new Promise((resolve, reject) => {
-    chrome.storage.sync.set({ wishlist: items }, () => {
-      if (chrome.runtime.lastError) {
-        reject(chrome.runtime.lastError);
-      } else {
-        resolve();
-      }
+  try {
+    await new Promise((resolve, reject) => {
+      chrome.storage.sync.set({ wishlist: items }, () => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+        } else {
+          resolve();
+        }
+      });
     });
-  });
+  } catch (err) {
+    if (/quota/i.test(err?.message || '')) {
+      if (typeof alert !== 'undefined') {
+        alert(
+          'Wishlist storage limit reached. Remove some items before adding more.',
+        );
+      }
+    }
+    throw err;
+  }
 }
 
 export async function addToWishlist(item) {


### PR DESCRIPTION
## Summary
- surface chrome.storage quota failures when saving wishlist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686abcf40e0c832f9da08ea35e6d1df2