### PR TITLE
Limit content script matches to store domains

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,17 @@
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>"
+        "*://www.zara.com/*",
+        "*://www.hm.com/*",
+        "*://www.uniqlo.com/*",
+        "*://www.nike.com/*",
+        "*://www.adidas.com/*",
+        "*://www.gucci.com/*",
+        "*://www.levi.com/*",
+        "*://www.gap.com/*",
+        "*://www.louisvuitton.com/*",
+        "*://www.underarmour.com/*",
+        "*://www.amazon.com/*"
       ],
       "js": [
         "src/content/content.js"


### PR DESCRIPTION
## Summary
- restrict the content script `matches` in `manifest.json` to only load on domains from `stores.json`

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686ac6130578832f964b89a3b58f893d