### PR TITLE
Add product scrape tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,7 @@ export default {
   },
   roots: ['<rootDir>/test'],
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
-  testPathIgnorePatterns: ['<rootDir>/test/productScrape.test.ts']
+  moduleNameMapper: {
+    '^\.\./utils/selectors.js$': '<rootDir>/src/utils/selectors.ts'
+  }
 };

--- a/test/html/prada.html
+++ b/test/html/prada.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "sku": "PR1",
+  "name": "Prada Bag",
+  "image": "https://example.com/prada.jpg",
+  "offers": {"price": "1999.99", "priceCurrency": "USD"}
+}
+</script>
+</head>
+<body>
+<h1 class="title">Prada Bag</h1>
+<span class="price">$1999.99</span>
+<div class="main"><img src="https://example.com/prada.jpg"/></div>
+<div class="gallery"><img src="https://example.com/prada1.jpg"/></div>
+<div class="similar">
+  <a href="/p1"><img src="/pr1.jpg" alt="pr1"/></a>
+  <a href="/p2"><img src="/pr2.jpg" alt="pr2"/></a>
+  <a href="/p3"><img src="/pr3.jpg" alt="pr3"/></a>
+  <a href="/p4"><img src="/pr4.jpg" alt="pr4"/></a>
+</div>
+</body>
+</html>

--- a/test/html/versace.html
+++ b/test/html/versace.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "sku": "VE1",
+  "name": "Versace Dress",
+  "image": "https://example.com/versace.jpg",
+  "offers": {"price": "1599.99", "priceCurrency": "USD"}
+}
+</script>
+</head>
+<body>
+<h1 class="title">Versace Dress</h1>
+<span class="price">$1599.99</span>
+<div class="main"><img src="https://example.com/versace.jpg"/></div>
+<div class="gallery"><img src="https://example.com/versace1.jpg"/></div>
+<div class="similar">
+  <a href="/p1"><img src="/ve1.jpg" alt="ve1"/></a>
+  <a href="/p2"><img src="/ve2.jpg" alt="ve2"/></a>
+  <a href="/p3"><img src="/ve3.jpg" alt="ve3"/></a>
+  <a href="/p4"><img src="/ve4.jpg" alt="ve4"/></a>
+</div>
+</body>
+</html>

--- a/test/productScrape.test.ts
+++ b/test/productScrape.test.ts
@@ -29,9 +29,11 @@ const cases = [
   ['gap', 'https://www.gap.com/product/1'],
   ['louisvuitton', 'https://www.louisvuitton.com/product/1'],
   ['underarmour', 'https://www.underarmour.com/product/1'],
+  ['prada', 'https://www.prada.com/product/1'],
+  ['versace', 'https://www.versace.com/product/1'],
 ];
 
-test.skip.each(cases)('scrape %s sample', async (name, url) => {
+test.each(cases)('scrape %s sample', async (name, url) => {
   const html = readFileSync(`${__dirname}/html/${name}.html`, 'utf-8');
   setup(html, url);
   const { product, similars } = await getProduct();
@@ -39,7 +41,7 @@ test.skip.each(cases)('scrape %s sample', async (name, url) => {
   expect(similars.length).toBeGreaterThanOrEqual(4);
 });
 
-test.skip('returns null when no product', async () => {
+test('returns null when no product', async () => {
   setup('<html></html>', 'https://example.com');
   const { product } = await getProduct();
   expect(product).toBeNull();


### PR DESCRIPTION
## Summary
- enable productScrape tests
- add sample product pages for Prada and Versace
- map selector imports for Jest

## Testing
- `npm test` *(fails: product scrape cases return null)*

------
https://chatgpt.com/codex/tasks/task_e_688687058d80832f9f2343f5be752590