### PR TITLE
Handle subdomain selectors

### DIFF
--- a/src/content/getProduct.ts
+++ b/src/content/getProduct.ts
@@ -1,5 +1,19 @@
 import { selectors } from '../utils/selectors.js';
 
+/**
+ * Lookup selector configuration for a hostname or its parent domains.
+ */
+function getSelectorsForHost(hostname: string) {
+  const clean = hostname.replace(/^www\./, '');
+  const parts = clean.split('.');
+  for (let i = 0; i <= parts.length - 2; i++) {
+    const domain = parts.slice(i).join('.');
+    const conf = selectors[domain];
+    if (conf) return conf;
+  }
+  return undefined;
+}
+
 export interface Product {
   id: string;
   title: string;
@@ -103,8 +117,7 @@ function fromOpenGraph(): Partial<Product> {
  * Fallback scraping using host specific selectors.
  */
 function fromSelectors(): Partial<Product> {
-  const host = window.location.hostname.replace(/^www\./, '');
-  const conf = selectors[host];
+  const conf = getSelectorsForHost(window.location.hostname);
   if (!conf) return {};
   const gallery: string[] = [];
   if (conf.gallery) {
@@ -202,9 +215,8 @@ function merge(base: Partial<Product> | null, ...rest: Array<Partial<Product>>):
  * Find similar products on the page.
  */
 function findSimilars(): SimilarProduct[] {
-  const host = window.location.hostname.replace(/^www\./, '');
   const res: SimilarProduct[] = [];
-  const conf = selectors[host];
+  const conf = getSelectorsForHost(window.location.hostname);
   let nodes: NodeListOf<Element> = [] as any;
   if (conf?.similar) nodes = document.querySelectorAll(conf.similar);
   if (!nodes.length) {

--- a/test/productScrape.test.ts
+++ b/test/productScrape.test.ts
@@ -20,6 +20,7 @@ const cases = [
   ['amazon', 'https://www.amazon.com/dp/test'],
   ['asos', 'https://www.asos.com/product/1'],
   ['zara', 'https://www.zara.com/product/1'],
+  ['zara', 'https://shop.zara.com/product/1'],
   ['hm', 'https://www.hm.com/product/1'],
   ['uniqlo', 'https://www.uniqlo.com/product/1'],
   ['nike', 'https://www.nike.com/product/1'],


### PR DESCRIPTION
## Summary
- add `getSelectorsForHost` helper in `getProduct`
- use the helper for fallback scraping and similar products
- test product scrape on a subdomain URL

## Testing
- `npm test` *(fails: productScrape.test.ts cases return null)*

------
https://chatgpt.com/codex/tasks/task_e_68869fba3f84832f9519735536b2e986