### PR TITLE
Add highlight class for product images

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -7,11 +7,14 @@
     const onStore = await isOnlineStore(currentUrl);
 
     function highlightProductImages() {
+      const highlighted = [];
       document.querySelectorAll('img').forEach((img) => {
         if (img.naturalWidth > 100 && img.naturalHeight > 100) {
-          img.style.outline = '2px solid #ff6600';
+          img.classList.add('imagine-highlight');
+          highlighted.push(img);
         }
       });
+      return highlighted;
     }
 
     async function detectProduct() {
@@ -29,14 +32,16 @@
     }
 
     if (onStore) {
+      const processPage = async () => {
+        const highlighted = highlightProductImages();
+        await detectProduct();
+        highlighted.forEach((img) => img.classList.remove('imagine-highlight'));
+      };
+
       if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', () => {
-          highlightProductImages();
-          detectProduct();
-        });
+        document.addEventListener('DOMContentLoaded', processPage);
       } else {
-        highlightProductImages();
-        detectProduct();
+        await processPage();
       }
     }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,3 +25,7 @@ html, body {
 .tab-content.active {
   opacity: 1;
 }
+
+.imagine-highlight {
+  outline: 2px solid #ff6600;
+}


### PR DESCRIPTION
## Summary
- add `.imagine-highlight` style
- use new class in content script and remove after detection finishes

## Testing
- `npm test` *(fails: productScrape.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6889380e6c50832fb870294088ad417c