### PR TITLE
Improve wishlist error handling with toast notifications

### DIFF
--- a/src/popup/modules/notification.js
+++ b/src/popup/modules/notification.js
@@ -1,0 +1,10 @@
+export function showMessage(message, duration = 3000) {
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  toast.setAttribute('role', 'alert');
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  setTimeout(() => {
+    toast.remove();
+  }, duration);
+}

--- a/src/popup/modules/wishlist.js
+++ b/src/popup/modules/wishlist.js
@@ -1,5 +1,6 @@
 import { requestTryOn } from './tryOnService.js';
 import { getSelectedPhotoId } from './photoStorage.js';
+import { showMessage } from './notification.js';
 
 export async function getWishlist() {
   return new Promise((resolve, reject) => {
@@ -26,11 +27,9 @@ export async function saveWishlist(items) {
     });
   } catch (err) {
     if (/quota/i.test(err?.message || '')) {
-      if (typeof alert !== 'undefined') {
-        alert(
-          'Wishlist storage limit reached. Remove some items before adding more.',
-        );
-      }
+      showMessage(
+        'Wishlist storage limit reached. Remove some items before adding more.',
+      );
     }
     throw err;
   }
@@ -158,7 +157,7 @@ export async function renderWishlist(container, items = null) {
         try {
           const photoId = await getSelectedPhotoId();
           if (!photoId) {
-            alert('Please select a photo in the Dressing Room first.');
+            showMessage('Please select a photo in the Dressing Room first.');
             return;
           }
           const url = await requestTryOn(photoId, item.imageSrc);
@@ -168,7 +167,7 @@ export async function renderWishlist(container, items = null) {
             window.open(url, '_blank');
           }
         } catch (err) {
-          alert(err.message);
+          showMessage(err.message);
         }
       });
       div.appendChild(tryBtn);

--- a/src/popup/styles/general.css
+++ b/src/popup/styles/general.css
@@ -79,3 +79,34 @@ h1 {
   display: block;
 }
 
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--color-primary);
+  color: var(--color-card);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  animation: toast-fade 3s forwards;
+}
+
+@keyframes toast-fade {
+  0% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `showMessage` helper for toast-style notifications
- use the helper in `wishlist.js` instead of blocking `alert` calls
- replace alerts when opening a try-on from the wishlist
- style the toast element in `general.css`

## Testing
- `npm test` *(fails: scrape tests expecting parsed products)*

------
https://chatgpt.com/codex/tasks/task_e_68893a34f0b8832fad180ebef07b49b7