### PR TITLE
Add Prada and Versace store support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,9 @@
         "*://www.gap.com/*",
         "*://www.louisvuitton.com/*",
         "*://www.underarmour.com/*",
-        "*://www.amazon.com/*"
+        "*://www.amazon.com/*",
+        "*://www.prada.com/*",
+        "*://www.versace.com/*"
       ],
       "js": [
         "src/content/content.js"

--- a/src/assets/data/stores.json
+++ b/src/assets/data/stores.json
@@ -86,5 +86,21 @@
     "targetDemographic": ["Men", "Women", "Kids"],
     "priceRange": "Mid",
     "url": "https://www.amazon.com/s?k=trending+fashion"
+  },
+  {
+    "name": "Prada",
+    "image": "src/assets/images/stores/prada.jpg",
+    "clothingType": "Accessories",
+    "targetDemographic": ["Women", "Men"],
+    "priceRange": "Luxury",
+    "url": "https://www.prada.com"
+  },
+  {
+    "name": "Versace",
+    "image": "src/assets/images/stores/versace.jpg",
+    "clothingType": "Dresses",
+    "targetDemographic": ["Women"],
+    "priceRange": "Luxury",
+    "url": "https://www.versace.com"
   }
 ]

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -96,4 +96,18 @@ export const selectors: Record<string, HostSelectors> = {
     gallery: '.gallery img',
     similar: '.similar a',
   },
+  'prada.com': {
+    title: '.title',
+    price: '.price',
+    mainImage: '.main img',
+    gallery: '.gallery img',
+    similar: '.similar a',
+  },
+  'versace.com': {
+    title: '.title',
+    price: '.price',
+    mainImage: '.main img',
+    gallery: '.gallery img',
+    similar: '.similar a',
+  },
 };


### PR DESCRIPTION
## Summary
- extend store data with Prada and Versace
- update manifest matches for their domains
- add selector fallbacks for Prada and Versace

## Testing
- `npm test` *(fails: productScrape.test.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688944c34b78832faa14f7042051e862