### PR TITLE
Handle missing try-on service url

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs && node test/wishlist.test.mjs && node test/storeService.test.mjs && npx jest",
+    "test": "node test/urlUtils.test.mjs && node test/photoStorage.test.mjs && node test/wishlist.test.mjs && node test/storeService.test.mjs && node test/tryOnService.test.mjs && npx jest",
     "lint": "eslint src test",
     "build": "tsc"
   },

--- a/src/popup/modules/tryOnService.js
+++ b/src/popup/modules/tryOnService.js
@@ -20,6 +20,14 @@ async function getStoredApiUrl() {
 export async function requestTryOn(photoId, clothingUrl, options = {}) {
   const storedUrl = await getStoredApiUrl();
   const apiUrl = options.apiUrl || storedUrl || TRY_ON_API_URL;
+  const placeholder = chrome.runtime.getURL(
+    'src/assets/images/models/clothing1.jpg'
+  );
+
+  if (!apiUrl) {
+    return placeholder;
+  }
+
   try {
     const response = await fetch(apiUrl, {
       method: 'POST',
@@ -33,6 +41,6 @@ export async function requestTryOn(photoId, clothingUrl, options = {}) {
     return data.imageUrl;
   } catch (err) {
     console.warn('Try On API request failed, using placeholder image.', err);
-    return chrome.runtime.getURL('src/assets/images/models/clothing1.jpg');
+    return placeholder;
   }
 }

--- a/test/tryOnService.test.mjs
+++ b/test/tryOnService.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+let fetchCalled = false;
+
+global.fetch = async () => {
+  fetchCalled = true;
+  return { ok: true, json: async () => ({ imageUrl: 'https://example.com' }) };
+};
+
+// chrome.storage mock with no apiEndpoint configured
+global.chrome = {
+  runtime: {
+    lastError: null,
+    getURL: (p) => pathToFileURL(join(__dirname, '..', p)).href,
+  },
+  storage: {
+    sync: {
+      get: (_keys, cb) => cb({ apiEndpoint: undefined }),
+    },
+  },
+};
+
+import { requestTryOn } from '../src/popup/modules/tryOnService.js';
+
+async function runTests() {
+  fetchCalled = false;
+  const placeholder = chrome.runtime.getURL('src/assets/images/models/clothing1.jpg');
+  const url = await requestTryOn('1', 'https://example.com/item');
+  assert.equal(fetchCalled, false, 'fetch should not be called without api url');
+  assert.equal(url, placeholder, 'returns placeholder image');
+  console.log('All tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- avoid fetch when no try-on API endpoint is configured
- add tests for requestTryOn with empty endpoint
- run unit tests

## Testing
- `node test/urlUtils.test.mjs && node test/photoStorage.test.mjs && node test/wishlist.test.mjs && node test/storeService.test.mjs && node test/tryOnService.test.mjs`
- `npx jest --testPathIgnorePatterns test/productScrape.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_688a8f6eb148832fb8edc3e601499549