### PR TITLE
chore: refine lint configuration and tidy lint suppressions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,12 +15,22 @@
   },
   "rules": {
     "indent": ["error", 2],
-    "semi": ["error", "always"]
+    "semi": ["error", "always"],
+    "@typescript-eslint/no-explicit-any": ["error", { "ignoreRestArgs": false }]
   },
   "overrides": [
     {
       "files": ["test/**/*.{ts,tsx,mjs}"],
       "env": { "jest": true, "node": true }
+    },
+    {
+      "files": ["test/**/*.{ts,tsx,mjs}", "**/*.d.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-require-imports": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/no-unused-expressions": "off"
+      }
     }
   ]
 }

--- a/src/content/getProduct.ts
+++ b/src/content/getProduct.ts
@@ -141,6 +141,7 @@ function fromSelectors(): Partial<Product> {
  * Attempt to read dedicated JSON blobs on the page.
  */
 function fromJsonBlob(): Product | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const state: any = (window as any).__PRELOADED_STATE__ || (window as any).__INITIAL_STATE__;
   if (state && state.product) {
     const p = state.product;
@@ -198,6 +199,7 @@ function fromJsonBlob(): Product | null {
  */
 function merge(base: Partial<Product> | null, ...rest: Array<Partial<Product>>): Product | null {
   if (!base) return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: any = { ...base };
   for (const obj of rest) {
     for (const [k, v] of Object.entries(obj)) {
@@ -217,6 +219,7 @@ function merge(base: Partial<Product> | null, ...rest: Array<Partial<Product>>):
 function findSimilars(): SimilarProduct[] {
   const res: SimilarProduct[] = [];
   const conf = getSelectorsForHost(window.location.hostname);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let nodes: NodeListOf<Element> = [] as any;
   if (conf?.similar) nodes = document.querySelectorAll(conf.similar);
   if (!nodes.length) {

--- a/src/popup/DressingRoomTab.tsx
+++ b/src/popup/DressingRoomTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Canvas, Image } from 'fabric';
@@ -94,10 +94,13 @@ export const DressingRoomTab: React.FC = () => {
     };
     const handlePointerMove = (e: PointerEvent) => {
       if (e.pointerType === 'touch' && e.isPrimary === false) {
-        const el = (e.target as HTMLElement).ownerDocument?.getElementsByTagName('canvas')[0] as any;
-        const touches = el?.touches as any;
-        if (touches && touches.length === 2) {
-          const [t1, t2] = touches;
+        const _el = (e.target as HTMLElement).ownerDocument?.getElementsByTagName('canvas')[0] as
+          | HTMLCanvasElement
+          | undefined;
+        const _touches = (_el as unknown as { touches?: TouchList })?.touches;
+        if (_touches && _touches.length === 2) {
+          const t1 = _touches[0];
+          const t2 = _touches[1];
           const dist = Math.hypot(t1.clientX - t2.clientX, t1.clientY - t2.clientY);
           if (!startDist) startDist = dist;
           const zoom = canvas.getZoom() * (dist / startDist);
@@ -127,8 +130,8 @@ export const DressingRoomTab: React.FC = () => {
   };
   const handleDelete = (id: string) => setItems((prev) => prev.filter((it) => it.id !== id));
 
-  const handleDragEnd = (event: any) => {
-    const { active, over } = event;
+  const handleDragEnd = (_event: DragEndEvent) => {
+    const { active, over } = _event;
     if (over && active.id !== over.id) {
       const oldIndex = items.findIndex((i) => i.id === active.id);
       const newIndex = items.findIndex((i) => i.id === over.id);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -96,7 +96,6 @@ function setupFilterToggle(elements, state) {
 function renderFilterOptions(elements, state) {
   const { filterSection, storeGrid, loadMoreButton, searchBar } = elements;
   const { stores } = state;
-  /* eslint-disable indent */
   filterSection.innerHTML = `
     <h3>Target Demographic</h3>
     ${generateCheckboxes('targetDemographic', [...new Set(stores.flatMap((s) => s.targetDemographic))], state.filters.targetDemographic)}
@@ -110,7 +109,6 @@ function renderFilterOptions(elements, state) {
       <button id="close-filters">Exit</button>
     </div>
   `;
-  /* eslint-enable indent */
 
   document.getElementById('apply-filters').addEventListener('click', () => {
     state.filters = {

--- a/test/productScrape.test.ts
+++ b/test/productScrape.test.ts
@@ -7,7 +7,6 @@ import { getProduct } from '../src/content/getProduct';
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder;
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { JSDOM } = require('jsdom');
 
 function setup(html: string, url: string) {


### PR DESCRIPTION
## Summary
- configure `@typescript-eslint/no-explicit-any` with stricter options and add test override
- scope unavoidable `any` usages with inline eslint-disable comments
- clean up unused lint disables and type `DragEndEvent`

## Testing
- `npm run lint --quiet`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_688e6492d8a4832fba78748bdef80f4e