### PR TITLE
feat: unify dressing room model thumbnails

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,9 @@
   "version": "1.0.0",
   "description": "Enhance your online apparel shopping experience with Imagine.",
   "icons": {
-    "16": "src/assets/icons/icon16.png",
-    "48": "src/assets/icons/icon48.png",
-    "128": "src/assets/icons/icon128.png"
+    "16": "src/assets/icons/icon16.webp",
+    "48": "src/assets/icons/icon48.webp",
+    "128": "src/assets/icons/icon128.webp"
   },
   "permissions": [
     "sidePanel",

--- a/src/popup/modules/photoGallery.js
+++ b/src/popup/modules/photoGallery.js
@@ -112,28 +112,26 @@ export function renderPhotoGallery(container, photos, selectedId) {
 
 export function renderModelGrid(container, photos, selectedId) {
   container.innerHTML = '';
-  photos.forEach((p) => {
-    const swatch = document.createElement('div');
-    swatch.className = 'model-swatch';
-    swatch.tabIndex = 0;
-    swatch.setAttribute('role', 'button');
-    swatch.setAttribute('aria-label', 'Select model');
+  photos.forEach((p, idx) => {
+    const swatch = document.createElement('button');
+    swatch.type = 'button';
+    swatch.className =
+      'model-swatch relative w-40 h-40 overflow-hidden rounded-xl shrink-0';
+    swatch.setAttribute('aria-label', `Model ${idx + 1}`);
     if (p.id === selectedId) swatch.classList.add('selected');
+
     const img = document.createElement('img');
     img.src = p.dataUrl;
-    img.alt = 'Model photo';
+    img.alt = `Model ${idx + 1}`;
+    img.className = 'absolute inset-0 w-full h-full object-cover';
     swatch.appendChild(img);
+
     const selectModel = async () => {
       await setSelectedPhotoId(p.id);
       await loadAndRenderPhotos();
     };
     swatch.addEventListener('click', selectModel);
-    swatch.addEventListener('keydown', async (e) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        await selectModel();
-      }
-    });
+
     container.appendChild(swatch);
   });
 }

--- a/src/popup/styles/dressing-room.css
+++ b/src/popup/styles/dressing-room.css
@@ -60,7 +60,6 @@
 .model-swatch-grid {
   display: flex;
   overflow: hidden;
-  width: 280px; /* Reduced grid width to display 3 swatches */
   gap: 10px;
   scroll-behavior: smooth;
   padding: 10px;
@@ -68,27 +67,14 @@
 
 /* Model Swatch */
 .model-swatch {
-  width: 70px; /* Reduced size of swatches */
-  height: 70px;
-  border-radius: 50%;
   background-color: var(--color-card);
   border: 2px solid var(--color-border);
-  display: flex;
-  justify-content: center;
-  align-items: center;
   transition: all 0.3s;
 }
 
 .model-swatch:focus {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
-}
-
-.model-swatch img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 50%;
 }
 
 .model-swatch:hover {

--- a/src/popup/styles/misc.css
+++ b/src/popup/styles/misc.css
@@ -18,7 +18,6 @@
 }
 
 .avatar-inputs input {
-  width: 100%;
   padding: 10px;
   margin-bottom: 10px;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- render model grid as accessible 160x160 buttons with object-cover images
- drop width/height CSS and obsolete rules
- remove fixed width in miscellaneous avatar inputs
- reference webp icons in manifest to restore build

## Testing
- `npm run lint --quiet`
- `npm test --coverage`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_688e7f436af0832fa3eb59f5de877781