### PR TITLE
Add end-to-end product extraction tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ export default {
     }
   },
   roots: ['<rootDir>/test'],
+  setupFiles: ['<rootDir>/test/setupTextEncoder.ts'],
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
   moduleNameMapper: {
     '^\.\./utils/selectors.js$': '<rootDir>/src/utils/selectors.ts'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint src test",
     "dev": "vite --mode development",
     "build": "vite build",
-    "analyze": "rollup-bundle-visualizer dist/manifest.json"
+    "analyze": "rollup-bundle-visualizer dist/manifest.json",
+    "test:e2e": "npm test -- -t 'end-to-end'"
   },
   "keywords": [],
   "author": "",

--- a/scripts/record-products.ts
+++ b/scripts/record-products.ts
@@ -1,0 +1,16 @@
+import { readdirSync, writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
+import { loadFixture } from '../test/helpers/loadFixture.js';
+import getProduct from '../src/content/getProduct.js';
+
+const fixturesDir = path.resolve('test/html');
+const goldenDir = path.resolve('test/golden');
+mkdirSync(goldenDir, { recursive: true });
+
+for (const file of readdirSync(fixturesDir)) {
+  if (!file.endsWith('.html')) continue;
+  const name = path.basename(file, '.html');
+  loadFixture(name);
+  const result = await getProduct();
+  writeFileSync(path.join(goldenDir, `${name}.json`), JSON.stringify(result, null, 2));
+}

--- a/src/content/getProduct.ts
+++ b/src/content/getProduct.ts
@@ -275,3 +275,5 @@ export async function getProduct() {
   }
   return { product, similars };
 }
+
+export default getProduct;

--- a/test/golden/adidas.json
+++ b/test/golden/adidas.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "AD1",
+    "title": "Adidas Shoes",
+    "priceCurrent": "89.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/adidas.jpg",
+    "imageGallery": [
+      "https://example.com/adidas.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "ad1",
+      "price": "",
+      "thumbnail": "https://adidas.com/ad1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "ad2",
+      "price": "",
+      "thumbnail": "https://adidas.com/ad2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "ad3",
+      "price": "",
+      "thumbnail": "https://adidas.com/ad3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "ad4",
+      "price": "",
+      "thumbnail": "https://adidas.com/ad4.jpg"
+    }
+  ]
+}

--- a/test/golden/amazon.json
+++ b/test/golden/amazon.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "AMZ1",
+    "title": "Amazon Shirt",
+    "priceCurrent": "19.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/img.jpg",
+    "imageGallery": [
+      "https://example.com/img.jpg"
+    ],
+    "rating": "4.5",
+    "reviewsCount": "20",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "t1",
+      "price": "",
+      "thumbnail": "https://amazon.com/t1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "t2",
+      "price": "",
+      "thumbnail": "https://amazon.com/t2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "t3",
+      "price": "",
+      "thumbnail": "https://amazon.com/t3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "t4",
+      "price": "",
+      "thumbnail": "https://amazon.com/t4.jpg"
+    }
+  ]
+}

--- a/test/golden/asos.json
+++ b/test/golden/asos.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "AS1",
+    "title": "ASOS Dress",
+    "priceCurrent": "29.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/a.jpg",
+    "imageGallery": [
+      "https://example.com/a.jpg"
+    ],
+    "rating": "4.2",
+    "reviewsCount": "15",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/s1",
+      "title": "s1",
+      "price": "",
+      "thumbnail": "https://asos.com/s1.jpg"
+    },
+    {
+      "id": "/s2",
+      "title": "s2",
+      "price": "",
+      "thumbnail": "https://asos.com/s2.jpg"
+    },
+    {
+      "id": "/s3",
+      "title": "s3",
+      "price": "",
+      "thumbnail": "https://asos.com/s3.jpg"
+    },
+    {
+      "id": "/s4",
+      "title": "s4",
+      "price": "",
+      "thumbnail": "https://asos.com/s4.jpg"
+    }
+  ]
+}

--- a/test/golden/gap.json
+++ b/test/golden/gap.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "GP1",
+    "title": "Gap Hoodie",
+    "priceCurrent": "49.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/gap.jpg",
+    "imageGallery": [
+      "https://example.com/gap.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "gp1",
+      "price": "",
+      "thumbnail": "https://gap.com/gp1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "gp2",
+      "price": "",
+      "thumbnail": "https://gap.com/gp2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "gp3",
+      "price": "",
+      "thumbnail": "https://gap.com/gp3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "gp4",
+      "price": "",
+      "thumbnail": "https://gap.com/gp4.jpg"
+    }
+  ]
+}

--- a/test/golden/gucci.json
+++ b/test/golden/gucci.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "GC1",
+    "title": "Gucci Bag",
+    "priceCurrent": "1999.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/gucci.jpg",
+    "imageGallery": [
+      "https://example.com/gucci.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "gc1",
+      "price": "",
+      "thumbnail": "https://gucci.com/gc1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "gc2",
+      "price": "",
+      "thumbnail": "https://gucci.com/gc2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "gc3",
+      "price": "",
+      "thumbnail": "https://gucci.com/gc3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "gc4",
+      "price": "",
+      "thumbnail": "https://gucci.com/gc4.jpg"
+    }
+  ]
+}

--- a/test/golden/hm.json
+++ b/test/golden/hm.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "HM1",
+    "title": "H&M Dress",
+    "priceCurrent": "39.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/hm.jpg",
+    "imageGallery": [
+      "https://example.com/hm.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "hm1",
+      "price": "",
+      "thumbnail": "https://hm.com/hm1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "hm2",
+      "price": "",
+      "thumbnail": "https://hm.com/hm2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "hm3",
+      "price": "",
+      "thumbnail": "https://hm.com/hm3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "hm4",
+      "price": "",
+      "thumbnail": "https://hm.com/hm4.jpg"
+    }
+  ]
+}

--- a/test/golden/levi.json
+++ b/test/golden/levi.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "LE1",
+    "title": "Levi Jeans",
+    "priceCurrent": "59.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/levi.jpg",
+    "imageGallery": [
+      "https://example.com/levi.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "le1",
+      "price": "",
+      "thumbnail": "https://levi.com/le1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "le2",
+      "price": "",
+      "thumbnail": "https://levi.com/le2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "le3",
+      "price": "",
+      "thumbnail": "https://levi.com/le3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "le4",
+      "price": "",
+      "thumbnail": "https://levi.com/le4.jpg"
+    }
+  ]
+}

--- a/test/golden/louisvuitton.json
+++ b/test/golden/louisvuitton.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "LV1",
+    "title": "LV Belt",
+    "priceCurrent": "499.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/lv.jpg",
+    "imageGallery": [
+      "https://example.com/lv.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "lv1",
+      "price": "",
+      "thumbnail": "https://louisvuitton.com/lv1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "lv2",
+      "price": "",
+      "thumbnail": "https://louisvuitton.com/lv2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "lv3",
+      "price": "",
+      "thumbnail": "https://louisvuitton.com/lv3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "lv4",
+      "price": "",
+      "thumbnail": "https://louisvuitton.com/lv4.jpg"
+    }
+  ]
+}

--- a/test/golden/nike.json
+++ b/test/golden/nike.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "NK1",
+    "title": "Nike Shoes",
+    "priceCurrent": "79.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/nike.jpg",
+    "imageGallery": [
+      "https://example.com/nike.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "nk1",
+      "price": "",
+      "thumbnail": "https://nike.com/nk1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "nk2",
+      "price": "",
+      "thumbnail": "https://nike.com/nk2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "nk3",
+      "price": "",
+      "thumbnail": "https://nike.com/nk3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "nk4",
+      "price": "",
+      "thumbnail": "https://nike.com/nk4.jpg"
+    }
+  ]
+}

--- a/test/golden/prada.json
+++ b/test/golden/prada.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "PR1",
+    "title": "Prada Bag",
+    "priceCurrent": "1999.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/prada.jpg",
+    "imageGallery": [
+      "https://example.com/prada.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "pr1",
+      "price": "",
+      "thumbnail": "https://prada.com/pr1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "pr2",
+      "price": "",
+      "thumbnail": "https://prada.com/pr2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "pr3",
+      "price": "",
+      "thumbnail": "https://prada.com/pr3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "pr4",
+      "price": "",
+      "thumbnail": "https://prada.com/pr4.jpg"
+    }
+  ]
+}

--- a/test/golden/underarmour.json
+++ b/test/golden/underarmour.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "UA1",
+    "title": "UA Shirt",
+    "priceCurrent": "29.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/ua.jpg",
+    "imageGallery": [
+      "https://example.com/ua.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "ua1",
+      "price": "",
+      "thumbnail": "https://underarmour.com/ua1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "ua2",
+      "price": "",
+      "thumbnail": "https://underarmour.com/ua2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "ua3",
+      "price": "",
+      "thumbnail": "https://underarmour.com/ua3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "ua4",
+      "price": "",
+      "thumbnail": "https://underarmour.com/ua4.jpg"
+    }
+  ]
+}

--- a/test/golden/uniqlo.json
+++ b/test/golden/uniqlo.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "UQ1",
+    "title": "Uniqlo Pants",
+    "priceCurrent": "29.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/uniqlo.jpg",
+    "imageGallery": [
+      "https://example.com/uniqlo.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "uq1",
+      "price": "",
+      "thumbnail": "https://uniqlo.com/uq1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "uq2",
+      "price": "",
+      "thumbnail": "https://uniqlo.com/uq2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "uq3",
+      "price": "",
+      "thumbnail": "https://uniqlo.com/uq3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "uq4",
+      "price": "",
+      "thumbnail": "https://uniqlo.com/uq4.jpg"
+    }
+  ]
+}

--- a/test/golden/versace.json
+++ b/test/golden/versace.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "VE1",
+    "title": "Versace Dress",
+    "priceCurrent": "1599.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/versace.jpg",
+    "imageGallery": [
+      "https://example.com/versace.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "ve1",
+      "price": "",
+      "thumbnail": "https://versace.com/ve1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "ve2",
+      "price": "",
+      "thumbnail": "https://versace.com/ve2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "ve3",
+      "price": "",
+      "thumbnail": "https://versace.com/ve3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "ve4",
+      "price": "",
+      "thumbnail": "https://versace.com/ve4.jpg"
+    }
+  ]
+}

--- a/test/golden/zara.json
+++ b/test/golden/zara.json
@@ -1,0 +1,47 @@
+{
+  "product": {
+    "id": "ZA1",
+    "title": "Zara Top",
+    "priceCurrent": "49.99",
+    "priceOld": "",
+    "currency": "USD",
+    "mainImage": "https://example.com/zara.jpg",
+    "imageGallery": [
+      "https://example.com/zara.jpg"
+    ],
+    "rating": "",
+    "reviewsCount": "",
+    "brand": "",
+    "seller": "",
+    "variants": [],
+    "breadcrumbs": [],
+    "availability": "",
+    "shippingCost": ""
+  },
+  "similars": [
+    {
+      "id": "/p1",
+      "title": "sz1",
+      "price": "",
+      "thumbnail": "https://zara.com/sz1.jpg"
+    },
+    {
+      "id": "/p2",
+      "title": "sz2",
+      "price": "",
+      "thumbnail": "https://zara.com/sz2.jpg"
+    },
+    {
+      "id": "/p3",
+      "title": "sz3",
+      "price": "",
+      "thumbnail": "https://zara.com/sz3.jpg"
+    },
+    {
+      "id": "/p4",
+      "title": "sz4",
+      "price": "",
+      "thumbnail": "https://zara.com/sz4.jpg"
+    }
+  ]
+}

--- a/test/helpers/loadFixture.ts
+++ b/test/helpers/loadFixture.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from "fs";
+import { JSDOM } from "jsdom";
+export function loadFixture(name: string) {
+  const html = readFileSync(`test/html/${name}.html`, "utf-8");
+  const dom  = new JSDOM(html, { url: `https://${name}.com` });
+  global.window   = dom.window as any;
+  global.document = dom.window.document as any;
+}

--- a/test/productExtraction.e2e.test.ts
+++ b/test/productExtraction.e2e.test.ts
@@ -1,0 +1,23 @@
+/** @jest-environment node */
+
+import { readFileSync } from "fs";
+import path from "path";
+import { loadFixture } from "./helpers/loadFixture";
+import getProduct from "../src/content/getProduct";
+
+const cases = [
+  "adidas","amazon","asos","gap","gucci","hm","levi",
+  "louisvuitton","nike","prada","underarmour","uniqlo",
+  "versace","zara"
+];
+
+describe("getProduct() end-to-end", () => {
+  test.each(cases)("end-to-end %s fixture", async site => {
+    loadFixture(site);
+    const result   = await getProduct();
+    const expected = JSON.parse(
+      readFileSync(path.join(__dirname, "golden", `${site}.json`), "utf-8")
+    );
+    expect(result).toMatchObject(expected);
+  });
+});

--- a/test/setupTextEncoder.ts
+++ b/test/setupTextEncoder.ts
@@ -1,0 +1,3 @@
+import { TextEncoder, TextDecoder } from 'util';
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { imagetools } from 'vite-imagetools';
 import { crx } from '@crxjs/vite-plugin';
 import { execSync } from 'node:child_process';
 
-import manifest from './manifest.json' assert { type: 'json' };
+import manifest from './manifest.json' with { type: 'json' };
 
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add fixture loader helper and golden-recording script for product extraction
- capture product data for multiple retailers and verify with end-to-end test suite
- wire up test script and build config adjustments

## Testing
- `npm run lint --quiet`
- `npm run test:e2e --coverage`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_688e9459e25c832f89d2f97da213e005