### PR TITLE
chore: add Lighthouse CI and improve accessibility

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,19 @@
+{
+  "ci": {
+    "collect": {
+      "url": [
+        "http://localhost:5173/src/popup/popup.html?theme=light",
+        "http://localhost:5173/src/popup/popup.html?theme=dark"
+      ],
+      "numberOfRuns": 3,
+      "settings": { "preset": "desktop" }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }]
+      }
+    },
+    "upload": { "target": "temporary-public-storage" }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "vite --mode development",
     "build": "vite build",
     "analyze": "rollup-bundle-visualizer dist/manifest.json",
-    "test:e2e": "npm test -- -t 'end-to-end'"
+    "test:e2e": "npm test -- -t 'end-to-end'",
+    "audit:lighthouse": "vite preview & lhci autorun && kill $!"
   },
   "keywords": [],
   "author": "",
@@ -28,6 +29,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.30.1",
     "@headlessui/react": "^2.2.4",
+    "@lhci/cli": "^0.15.1",
     "@mui/material": "^5.15.13",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-checkbox": "^1.3.2",
@@ -55,6 +57,7 @@
     "jest-environment-jsdom": "^30.0.4",
     "lucide-react": "^0.536.0",
     "postcss": "^8.5.6",
+    "puppeteer": "^24.15.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-window": "^1.8.7",

--- a/src/components/SimilarProductsCarousel.tsx
+++ b/src/components/SimilarProductsCarousel.tsx
@@ -20,6 +20,7 @@ export const SimilarProductsCarousel: React.FC<Props> = ({ items }) => (
           <img
             src={item.image}
             alt={item.name}
+            loading="lazy"
             className="rounded-lg aspect-square object-cover w-full"
           />
           <p className="text-sm mt-1">{item.name}</p>

--- a/src/popup/DressingRoomTab.tsx
+++ b/src/popup/DressingRoomTab.tsx
@@ -31,7 +31,12 @@ const ItemCard: React.FC<ItemProps> = ({ item, onChangeQty, onDelete }) => {
   };
   return (
     <div ref={setNodeRef} style={style} className="border rounded p-2 flex items-start space-x-2 bg-white dark:bg-gray-800" {...attributes} {...listeners}>
-      <img src={item.image} alt="thumbnail" className="w-16 h-16 object-cover rounded" />
+      <img
+        src={item.image}
+        alt="thumbnail"
+        loading="lazy"
+        className="w-16 h-16 object-cover rounded"
+      />
       <div className="flex-1">
         <div className="flex space-x-1 mb-1">
           {item.variants.map(v => (

--- a/src/popup/ProductTab.tsx
+++ b/src/popup/ProductTab.tsx
@@ -68,6 +68,7 @@ export const ProductTab: React.FC<Props> = ({ product, loading }) => {
       <img
         src={product.image}
         alt={product.name}
+        loading="lazy"
         className="w-full aspect-square object-cover rounded-xl mb-4 sm:mb-0"
       />
       <div>

--- a/src/popup/StoresTab.tsx
+++ b/src/popup/StoresTab.tsx
@@ -87,7 +87,12 @@ export const StoresTab: React.FC<Props> = ({ initialStores }) => {
       <div className="grid grid-cols-2 gap-4 overflow-auto">
         {filtered.map((store) => (
           <a key={store.name} href={store.url} className="text-center">
-            <img src={store.image} alt={store.name} className="w-full rounded-xl mb-1" />
+            <img
+              src={store.image}
+              alt={store.name}
+              loading="lazy"
+              className="w-full rounded-xl mb-1"
+            />
             <p>{store.name}</p>
           </a>
         ))}

--- a/src/popup/modules/tryOnInteractions.js
+++ b/src/popup/modules/tryOnInteractions.js
@@ -11,6 +11,7 @@ export function setupTryOnButton() {
   if (!btn) return;
   btn.textContent = 'Open Try-On';
   btn.title = 'Open the virtual try-on dialog';
+  btn.setAttribute('aria-label', 'Open the virtual try-on dialog');
   btn.addEventListener('click', () => {
     const img = document.querySelector('.product-image');
     const url = img?.src;
@@ -48,6 +49,7 @@ export async function showPhotoDialog(clothingUrl) {
 
     const btn = document.createElement('button');
     btn.textContent = 'Try On';
+    btn.setAttribute('aria-label', 'Try on with this photo');
     btn.addEventListener('click', async () => {
       overlay.remove();
       try {

--- a/src/popup/modules/wishlist.js
+++ b/src/popup/modules/wishlist.js
@@ -155,6 +155,7 @@ export async function renderWishlist(container, items = null) {
       const tryBtn = document.createElement('button');
       tryBtn.className = 'try-on-btn btn btn-primary btn-rounded';
       tryBtn.textContent = 'Try On';
+      tryBtn.setAttribute('aria-label', 'Try on item');
       tryBtn.addEventListener('click', async () => {
         try {
           const photoId = await getSelectedPhotoId();

--- a/src/popup/modules/wishlistUi.js
+++ b/src/popup/modules/wishlistUi.js
@@ -16,6 +16,7 @@ export function initWishlistUi() {
 function setupWishlistListener() {
   const wishlistBtn = document.querySelector('.wishlist-btn');
   if (!wishlistBtn) return;
+  wishlistBtn.setAttribute('aria-label', 'Add to wishlist');
 
   const url = window.location.href;
   isInWishlist(url).then((present) => {

--- a/src/popup/partials/product-discovery.html
+++ b/src/popup/partials/product-discovery.html
@@ -4,8 +4,9 @@
       src="/src/assets/images/stores/adidas.jpg"
       alt="Product Image"
       class="product-image"
+      loading="lazy"
     />
-    <button class="wishlist-btn btn btn-rounded" aria-label="Toggle wishlist">❤️</button>
+    <button class="wishlist-btn btn btn-rounded" aria-label="Add to wishlist">❤️</button>
   </div>
 
   <div class="product-info">
@@ -16,7 +17,7 @@
   <p class="product-placeholder" style="display: none">No product detected on this page.</p>
 
   <div class="try-on-button">
-    <button class="btn btn-primary btn-rounded" title="Open the virtual try-on dialog">Open Try-On</button>
+    <button class="btn btn-primary btn-rounded" title="Open the virtual try-on dialog" aria-label="Open the virtual try-on dialog">Open Try-On</button>
   </div>
 
   <div class="product-colors-section">

--- a/src/ui/button.tsx
+++ b/src/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground hover:bg-primary/90",
+          "bg-indigo-950 text-white hover:bg-indigo-900",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:


### PR DESCRIPTION
## Summary
- add lighthouserc and audit script
- improve lazy loading and aria labels for images and buttons
- adjust default button colors for contrast

## Testing
- `npm run lint --quiet`
- `npm run test:e2e`
- `yarn build`
- `npm run audit:lighthouse` *(fails: Run #1...failed!)*

------
https://chatgpt.com/codex/tasks/task_e_688f58a9f0f0832fbed1adceaec4ba66