### PR TITLE
chore: disable Chrome sandbox for LHCI

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,7 +6,10 @@
         "http://localhost:5173/src/popup/popup.html?theme=dark"
       ],
       "numberOfRuns": 3,
-      "settings": { "preset": "desktop" }
+      "settings": {
+        "preset": "desktop",
+        "chromeFlags": "--no-sandbox --disable-dev-shm-usage"
+      }
     },
     "assert": {
       "assertions": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "analyze": "rollup-bundle-visualizer dist/manifest.json",
     "test:e2e": "npm test -- -t 'end-to-end'",
     "audit:lighthouse": "vite preview & lhci autorun && kill $!",
-    "lhci": "vite preview --port 5173 & lhci autorun --upload.target=temporary-public-storage && pkill -f vite"
+    "lhci": "vite preview --port 5173 --host 0.0.0.0 & lhci autorun --upload.target=temporary-public-storage && pkill -f vite"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add Chrome flags to disable sandbox for Lighthouse CI
- expose preview server on 0.0.0.0

## Testing
- `yarn install --immutable`
- `npm run lhci` *(failed: Chrome prevented page load with interstitial error)*

------
https://chatgpt.com/codex/tasks/task_e_688f6cdb15c8832f811fd15f866e1744