### PR TITLE
test: add Card component tests

### DIFF
--- a/test/auto/src/ui/__snapshots__/card.test.tsx.snap
+++ b/test/auto/src/ui/__snapshots__/card.test.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card renders header + content 1`] = `
+<div>
+  <div
+    class="rounded-lg border bg-card text-card-foreground shadow-sm"
+  >
+    <div
+      class="flex flex-col space-y-1.5 p-6"
+    >
+      <h3
+        class="text-2xl font-semibold leading-none tracking-tight"
+      >
+        Title
+      </h3>
+      <p
+        class="text-sm text-muted-foreground"
+      >
+        Subtitle
+      </p>
+    </div>
+    <div
+      class="p-6 pt-0"
+    >
+      Body
+    </div>
+    <div
+      class="flex items-center p-6 pt-0"
+    >
+      Footer
+    </div>
+  </div>
+</div>
+`;

--- a/test/auto/src/ui/card.test.tsx
+++ b/test/auto/src/ui/card.test.tsx
@@ -1,14 +1,39 @@
 import { render } from '@testing-library/react';
-import { Card, CardHeader, CardContent } from '../../../../src/ui/card';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '../../../../src/ui/card';
 
 describe('Card', () => {
-  it('renders header and content', () => {
-    render(
+  it('renders header + content', () => {
+    const { getByText, container } = render(
       <Card>
-        <CardHeader />
-        <CardContent />
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+          <CardDescription>Subtitle</CardDescription>
+        </CardHeader>
+        <CardContent>Body</CardContent>
+        <CardFooter>Footer</CardFooter>
       </Card>
     );
-    // TODO: assert rendered output
+
+    expect(getByText('Title')).toBeInTheDocument();
+    expect(getByText('Subtitle')).toBeInTheDocument();
+    expect(getByText('Body')).toBeInTheDocument();
+    expect(getByText('Footer')).toBeInTheDocument();
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('forwards extra className & data attributes', () => {
+    const { getByTestId } = render(
+      <Card data-testid="root" className="bg-red-500" />
+    );
+
+    expect(getByTestId('root')).toHaveClass('bg-red-500');
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests for Card component rendering and className forwarding
- snapshot Card structure

## Testing
- `npm test -- --coverage --runTestsByPath test/auto/src/ui/card.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6890b2a9cda4832fa94d9041e454ef6e