### PR TITLE
test: add sorting and tag filtering tests for StoresTab

### DIFF
--- a/test/auto/src/popup/StoresTab.test.tsx
+++ b/test/auto/src/popup/StoresTab.test.tsx
@@ -1,9 +1,86 @@
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { StoresTab } from '../../../../src/popup/StoresTab';
 
+(global as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 describe('StoresTab', () => {
-  it('sorts stores by name descending', () => {
-    render(<StoresTab initialStores={[]} />);
-    // TODO: provide initialStores and trigger apply with sort "Name (Z-A)"
+  it('sorts stores by name descending', async () => {
+    const stores = [
+      {
+        name: 'Adidas',
+        image: '',
+        clothingType: 'type',
+        targetDemographic: [],
+        priceRange: 'Low',
+        url: '#a',
+      },
+      {
+        name: 'Gucci',
+        image: '',
+        clothingType: 'type',
+        targetDemographic: [],
+        priceRange: 'Low',
+        url: '#b',
+      },
+      {
+        name: 'Nike',
+        image: '',
+        clothingType: 'type',
+        targetDemographic: [],
+        priceRange: 'Low',
+        url: '#c',
+      },
+    ];
+
+    const { container } = render(<StoresTab initialStores={stores} />);
+    await screen.findByText('Adidas');
+
+    fireEvent.click(screen.getByLabelText('Name (Z-A)'));
+    const apply = screen.getAllByLabelText('Apply Filters')[0];
+    fireEvent.click(apply);
+
+    const names = screen
+      .getAllByRole('link')
+      .map((link) => link.textContent?.trim());
+    expect(names).toEqual(['Nike', 'Gucci', 'Adidas']);
+
+    const list = container.querySelector('.grid-cols-2');
+    expect(list).toMatchSnapshot();
+  });
+
+  it('filters by tag', async () => {
+    const stores = [
+      {
+        name: 'Gap',
+        image: '',
+        clothingType: 'type',
+        targetDemographic: ['Kids'],
+        priceRange: 'Low',
+        url: '#g',
+      },
+      {
+        name: 'HM',
+        image: '',
+        clothingType: 'type',
+        targetDemographic: ['Women'],
+        priceRange: 'Low',
+        url: '#h',
+      },
+    ];
+
+    render(<StoresTab initialStores={stores} />);
+    await screen.findByText('Gap');
+
+    const kidsButton = screen.getByRole('button', { name: 'Kids' });
+    fireEvent.click(kidsButton);
+    const apply = screen.getAllByLabelText('Apply Filters')[0];
+    fireEvent.click(apply);
+
+    expect(screen.getByText('Gap')).toBeInTheDocument();
+    expect(screen.queryByText('HM')).toBeNull();
   });
 });

--- a/test/auto/src/popup/__snapshots__/StoresTab.test.tsx.snap
+++ b/test/auto/src/popup/__snapshots__/StoresTab.test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StoresTab sorts stores by name descending 1`] = `
+<div
+  class="grid grid-cols-2 gap-4 overflow-auto"
+>
+  <a
+    class="text-center"
+    href="#c"
+  >
+    <img
+      alt="Nike"
+      class="w-full rounded-xl mb-1"
+      loading="lazy"
+      src=""
+    />
+    <p>
+      Nike
+    </p>
+  </a>
+  <a
+    class="text-center"
+    href="#b"
+  >
+    <img
+      alt="Gucci"
+      class="w-full rounded-xl mb-1"
+      loading="lazy"
+      src=""
+    />
+    <p>
+      Gucci
+    </p>
+  </a>
+  <a
+    class="text-center"
+    href="#a"
+  >
+    <img
+      alt="Adidas"
+      class="w-full rounded-xl mb-1"
+      loading="lazy"
+      src=""
+    />
+    <p>
+      Adidas
+    </p>
+  </a>
+</div>
+`;


### PR DESCRIPTION
## Summary
- add regression tests verifying name-descending sort and tag filtering in StoresTab
- snapshot sorted stores list

## Testing
- `npm test -- --coverage --runTestsByPath test/auto/src/popup/StoresTab.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6890b5c0d50c832f9e43bcbf18624208