### PR TITLE
test: add theme toggle and filter chip tests

### DIFF
--- a/src/react-filters/FilterChip.tsx
+++ b/src/react-filters/FilterChip.tsx
@@ -2,12 +2,39 @@ import React from 'react';
 
 type Props = {
   label: string;
-  onRemove: () => void;
+  active?: boolean;
+  onToggle?: (active: boolean) => void;
+  onRemove?: () => void;
 };
 
-export const FilterChip: React.FC<Props> = ({ label, onRemove }) => (
-  <span className="bg-primary text-white px-2 py-1 rounded flex items-center space-x-1 mr-2 mb-2" role="button" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && onRemove()} onClick={onRemove}>
-    <span>{label}</span>
-    <button aria-label={`Remove ${label}`} className="ml-1 text-white">×</button>
-  </span>
-);
+export const FilterChip: React.FC<Props> = ({
+  label,
+  active = false,
+  onToggle,
+  onRemove,
+}) => {
+  const handleClick = () => {
+    if (onToggle) {
+      onToggle(!active);
+    } else if (onRemove) {
+      onRemove();
+    }
+  };
+
+  return (
+    <span
+      className="bg-primary text-white px-2 py-1 rounded flex items-center space-x-1 mr-2 mb-2"
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => e.key === 'Enter' && handleClick()}
+      onClick={handleClick}
+    >
+      <span>{label}</span>
+      {onRemove && (
+        <button aria-label={`Remove ${label}`} className="ml-1 text-white">
+          ×
+        </button>
+      )}
+    </span>
+  );
+};

--- a/test/react/filterChip.test.tsx
+++ b/test/react/filterChip.test.tsx
@@ -1,0 +1,14 @@
+import { render, fireEvent } from '@testing-library/react';
+import { FilterChip } from '../../src/react-filters/FilterChip';
+
+describe('FilterChip', () => {
+  it('invokes onToggle', () => {
+    const spy = jest.fn();
+    const { getByText } = render(
+      <FilterChip label="Women" active={false} onToggle={spy} />
+    );
+    fireEvent.click(getByText('Women'));
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+});
+

--- a/test/react/themeToggle.test.tsx
+++ b/test/react/themeToggle.test.tsx
@@ -1,0 +1,12 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeToggle } from '../../src/ui/theme-toggle';
+
+describe('ThemeToggle', () => {
+  it('toggles dark / light mode', () => {
+    const { getByRole } = render(<ThemeToggle />);
+    const btn = getByRole('button');
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+  });
+});
+

--- a/test/setupTextEncoder.ts
+++ b/test/setupTextEncoder.ts
@@ -1,3 +1,16 @@
 import { TextEncoder, TextDecoder } from 'util';
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder;
+(global as any).chrome = {
+  storage: {
+    sync: {
+      get: (_: any, cb: (res: any) => void) => cb({}),
+      set: () => {},
+    },
+    local: {
+      get: (_: any, cb: (res: any) => void) => cb({}),
+      set: () => {},
+    },
+  },
+  runtime: { getURL: (p: string) => p },
+};


### PR DESCRIPTION
## Summary
- expand `FilterChip` to support toggling and add tests for ThemeToggle and FilterChip
- provide default chrome stub for tests

## Testing
- `npm run lint --quiet`
- `npm test -- --coverage` *(fails: returns placeholder image)*
- `yarn build`
- `npm run size:gzip`


------
https://chatgpt.com/codex/tasks/task_e_689259f5b3dc832f89573c3dd015d44b