### PR TITLE
Fix placeholder test and theme toggle role

### DIFF
--- a/test/react/themeToggle.test.tsx
+++ b/test/react/themeToggle.test.tsx
@@ -4,7 +4,7 @@ import { ThemeToggle } from '../../src/ui/theme-toggle';
 describe('ThemeToggle', () => {
   it('toggles dark / light mode', () => {
     const { getByRole } = render(<ThemeToggle />);
-    const btn = getByRole('button');
+    const btn = getByRole('switch');
     fireEvent.click(btn);
     fireEvent.click(btn);
   });

--- a/test/tryOnService.test.mjs
+++ b/test/tryOnService.test.mjs
@@ -29,7 +29,7 @@ import { requestTryOn } from '../src/popup/modules/tryOnService.js';
 
 async function runTests() {
   fetchCalled = false;
-  const placeholder = chrome.runtime.getURL('src/assets/images/models/clothing1.webp');
+  const placeholder = chrome.runtime.getURL('src/assets/images/models/clothing1.jpg');
   const url = await requestTryOn('1', 'https://example.com/item');
   assert.equal(fetchCalled, false, 'fetch should not be called without api url');
   assert.equal(url, placeholder, 'returns placeholder image');


### PR DESCRIPTION
## Summary
- update try-on service test to expect the actual JPG placeholder image
- query the switch role in ThemeToggle test instead of button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892687e1370832fbab061cd93817d4f