### PR TITLE
Build popup to dist and update loading instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ npm run lint
 
 The lint script checks the `src` and `test` directories using ESLint.
 
+### Loading in Chrome
+
+Always run `yarn build` first, then choose **dist/** as the
+"Load unpacked" folder in `chrome://extensions`. Loading the
+raw `src/` files will fail with a MIME-type error.
+
 ## Building and Packaging
 
 Compile the TypeScript sources before packaging the extension:

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
     "type": "module"
   },
   "action": {
-    "default_title": "Open side panel"
+    "default_title": "Open side panel",
+    "default_popup": "dist/popup.html"
   },
   "side_panel": {
     "default_path": "src/popup/popup.html"

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -7,6 +7,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./popup.tsx"></script>
   </body>
 </html>

--- a/test/tryOnService.test.mjs
+++ b/test/tryOnService.test.mjs
@@ -29,7 +29,7 @@ import { requestTryOn } from '../src/popup/modules/tryOnService.js';
 
 async function runTests() {
   fetchCalled = false;
-  const placeholder = chrome.runtime.getURL('src/assets/images/models/clothing1.jpg');
+  const placeholder = chrome.runtime.getURL('src/assets/images/models/clothing1.webp');
   const url = await requestTryOn('1', 'https://example.com/item');
   assert.equal(fetchCalled, false, 'fetch should not be called without api url');
   assert.equal(url, placeholder, 'returns placeholder image');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,30 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { imagetools } from 'vite-imagetools';
-import { crx } from '@crxjs/vite-plugin';
 import { execSync } from 'node:child_process';
 import stripBigIcons from './vite.plugins/stripBigIcons';
-
-import manifest from './manifest.json' with { type: 'json' };
 
 
 export default defineConfig({
   plugins: [
     react(),
     imagetools(),
-    stripBigIcons(),
-    crx({ manifest })
+    stripBigIcons()
 
   ],
   build: {
     target: 'chrome117',
     minify: 'terser',
     sourcemap: false,
-    rollupOptions: { output: { manualChunks: undefined } }
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        popup: 'src/popup/popup.html',
+        background: 'src/background/background.js',
+      },
+      output: { manualChunks: undefined }
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- load built popup in extension manifest
- let Vite inject popup script instead of TS import
- add multi-entry build config targeting `dist`
- document loading the built extension in Chrome
- adjust try-on test for WebP placeholder

## Testing
- `npm run lint --quiet`
- `npm test -- --coverage`
- `yarn build`
- `npm run size:gzip`


------
https://chatgpt.com/codex/tasks/task_e_68933bbaef1c832fbfa26905de85c0b4