### PR TITLE
docs: clarify node requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Chrome extension for the Imagine service.
 
 ## Development
 
-Install dependencies (Node.js v18 or later is required) and run linting:
+Install dependencies (Node.js **v20.19 or later** is required) and run linting:
 
 ```bash
 npm install
@@ -23,7 +23,7 @@ The lint script checks the `src` and `test` directories using ESLint.
 
 ### Loading in Chrome
 
-Always run `yarn build` first, then choose **dist/** as the
+Always run `npm run build` first, then choose **dist/** as the
 "Load unpacked" folder in `chrome://extensions`. Loading the
 raw `src/` files will fail with a MIME-type error.
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "description": "Imagine browser extension",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19.0"
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.3",


### PR DESCRIPTION
## Summary
- document that the extension requires Node.js v20.19+
- mention `npm run build` when loading the extension in Chrome

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689349b0f12c832f97739a098e8a0d25