### PR TITLE
Fix image optimization rename error and add image fallbacks

### DIFF
--- a/scripts/optimize-images.ts
+++ b/scripts/optimize-images.ts
@@ -33,6 +33,7 @@ async function walk(dir: string): Promise<void> {
           .resize(size, size, { fit: 'inside' })
           .webp({ quality: 80 })
           .toFile(tmp);
+        await fs.unlink(full);
         await fs.rename(tmp, full);
       }
     }

--- a/src/popup/modules/tryOnInteractions.js
+++ b/src/popup/modules/tryOnInteractions.js
@@ -1,5 +1,6 @@
 import { requestTryOn } from './tryOnService.js';
 import { notify } from '../../ui/toast.js';
+import placeholderIcon from '../../assets/icons/icon128.png';
 
 export function initTryOnUi() {
   setupTryOnButton();
@@ -111,7 +112,7 @@ function renderProductInfo(info) {
   const placeholder = document.querySelector('.product-placeholder');
   if (placeholder) placeholder.style.display = 'none';
   const imageEl = document.querySelector('.product-image');
-  if (imageEl && info.image) imageEl.src = info.image;
+  if (imageEl) imageEl.src = info.image || placeholderIcon;
   const nameEl = document.querySelector('.product-name');
   if (nameEl && info.name) nameEl.textContent = info.name;
   const priceEl = document.querySelector('.product-price');
@@ -172,7 +173,8 @@ function renderProductInfo(info) {
       if (item.url) link.href = item.url;
 
       const img = document.createElement('img');
-      img.src = item.image;
+      img.src = item.image || placeholderIcon;
+      img.alt = item.name || 'Product image';
       link.appendChild(img);
       div.appendChild(link);
 

--- a/src/popup/modules/tryOnService.js
+++ b/src/popup/modules/tryOnService.js
@@ -17,10 +17,10 @@ async function getStoredApiUrl() {
 // override the API URL by passing `options.apiUrl` or setting the value in the
 // Options page. Returns the URL of the processed image on success and throws on
 // failure. If the request fails, a placeholder image is returned.
-export async function requestTryOn(photoId, clothingUrl, options = {}) {
-  const storedUrl = await getStoredApiUrl();
-  const apiUrl = options.apiUrl || storedUrl || TRY_ON_API_URL;
-  const fallback = 'https://example.com/placeholder.jpg';
+  export async function requestTryOn(photoId, clothingUrl, options = {}) {
+    const storedUrl = await getStoredApiUrl();
+    const apiUrl = options.apiUrl || storedUrl || TRY_ON_API_URL;
+    const fallback = chrome.runtime.getURL('assets/icons/icon128.png');
 
   if (!apiUrl) {
     return fallback;

--- a/test/tryOnService.test.mjs
+++ b/test/tryOnService.test.mjs
@@ -29,7 +29,7 @@ import { requestTryOn } from '../src/popup/modules/tryOnService.js';
 
 async function runTests() {
   fetchCalled = false;
-  const placeholder = 'https://example.com/placeholder.jpg';
+  const placeholder = chrome.runtime.getURL('assets/icons/icon128.png');
   const url = await requestTryOn('1', 'https://example.com/item');
   assert.equal(fetchCalled, false, 'fetch should not be called without api url');
   assert.equal(url, placeholder, 'returns placeholder image');


### PR DESCRIPTION
## Summary
- avoid Windows rename errors in optimize-images by unlinking the original before renaming
- show a default icon whenever product or recommendation images are missing
- use a local icon as the try-on API fallback and update tests accordingly

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893a93c763c832f957ae15f039ff159