### PR TITLE
fix: handle locked assets during image optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "zustand": "^4.5.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1638,9 +1638,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/scripts/optimize-images.ts
+++ b/scripts/optimize-images.ts
@@ -2,6 +2,28 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import sharp from 'sharp';
 
+// Disable Sharp's cache to avoid keeping file handles open on Windows
+sharp.cache(false);
+
+async function safeUnlink(file: string): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    try {
+      await fs.unlink(file);
+      return;
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') {
+        return;
+      }
+      if (err?.code === 'EBUSY' || err?.code === 'EPERM') {
+        // wait briefly and retry to handle Windows file locking
+        await new Promise(res => setTimeout(res, 100));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
 const assetsDir = path.resolve('src/assets');
 const threshold = 0; // always optimize
 
@@ -24,7 +46,7 @@ async function walk(dir: string): Promise<void> {
           .resize(size, size, { fit: 'inside' })
           .webp({ quality: 80 })
           .toFile(webpPath);
-        await fs.unlink(full);
+        await safeUnlink(full);
         mappings.push({ old: path.basename(full), webp: path.basename(webpPath) });
       } else if (ext === '.webp') {
         const size = iconMatch ? parseInt(iconMatch[1], 10) : 256;
@@ -33,7 +55,7 @@ async function walk(dir: string): Promise<void> {
           .resize(size, size, { fit: 'inside' })
           .webp({ quality: 80 })
           .toFile(tmp);
-        await fs.unlink(full);
+        await safeUnlink(full);
         await fs.rename(tmp, full);
       }
     }


### PR DESCRIPTION
## Summary
- avoid Windows file locking during image optimization by adding a retryable `safeUnlink`
- disable Sharp cache to release file handles
- update dependencies with `npm audit fix`

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893b0f71968832f8d033ec4c17b16fb