### PR TITLE
fix: make post-build scripts cross-platform

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,15 +15,16 @@ export default defineConfig({
       name: 'post-build-tasks',
       closeBundle() {
         console.log('🔧 Running post-build image optimization...');
+        const env = { ...process.env, TS_NODE_TRANSPILE_ONLY: 'true' };
         execSync(
-          'TS_NODE_TRANSPILE_ONLY=true node --no-warnings --loader ts-node/esm scripts/optimize-images.ts',
-          { stdio: 'inherit' }
+          'node --no-warnings --loader ts-node/esm scripts/optimize-images.ts',
+          { stdio: 'inherit', env }
         );
 
         console.log('📝 Copying and adjusting manifest...');
         execSync(
-          'TS_NODE_TRANSPILE_ONLY=true node --no-warnings --loader ts-node/esm scripts/update-manifest.ts',
-          { stdio: 'inherit' }
+          'node --no-warnings --loader ts-node/esm scripts/update-manifest.ts',
+          { stdio: 'inherit', env }
         );
       }
     }


### PR DESCRIPTION
## Summary
- fix post-build tasks failing on Windows by setting env vars via Node instead of shell syntax

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c5909870832f91575d8da237eb32