### PR TITLE
Fix popup initialization and remove React toast from service worker

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -7,5 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="module" src="./popup.tsx"></script>
   </body>
 </html>

--- a/src/ui/toast.js
+++ b/src/ui/toast.js
@@ -1,8 +1,16 @@
-import { toast } from 'sonner';
-
+/**
+ * Displays a toast notification if the UI libraries are available.
+ * Falls back silently when executed in non-UI environments such as the
+ * background service worker where React based libraries are unavailable.
+ */
 export const notify = (msg) => {
   try {
-    toast.success(msg);
+    // Dynamically import to avoid bundling React/DOM dependant code
+    import('sonner')
+      .then(({ toast }) => toast.success(msg))
+      .catch(() => {
+        /* ignore outside browser environments */
+      });
   } catch {
     // ignore outside browser environments
   }


### PR DESCRIPTION
## Summary
- load popup React entrypoint explicitly so the panel renders
- show toast notifications only in UI contexts to keep background worker light

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c72f5d60832f9b7788f4a8d04bb6