### PR TITLE
Fix store data path and filter panel layout

### DIFF
--- a/src/assets/data/stores.json
+++ b/src/assets/data/stores.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Zara",
-    "image": "src/assets/images/stores/zara.jpg",
+    "image": "images/stores/zara.jpg",
     "clothingType": "Shirts",
     "targetDemographic": ["Men", "Women"],
     "priceRange": "Mid",
@@ -9,7 +9,7 @@
   },
   {
     "name": "H&M",
-    "image": "src/assets/images/stores/hm.jpg",
+    "image": "images/stores/hm.jpg",
     "clothingType": "Dresses",
     "targetDemographic": ["Women"],
     "priceRange": "Low",
@@ -17,7 +17,7 @@
   },
   {
     "name": "Uniqlo",
-    "image": "src/assets/images/stores/uniqlo.jpg",
+    "image": "images/stores/uniqlo.jpg",
     "clothingType": "Pants",
     "targetDemographic": ["Kids", "Men", "Women"],
     "priceRange": "Mid",
@@ -25,7 +25,7 @@
   },
   {
     "name": "Nike",
-    "image": "src/assets/images/stores/nike.jpg",
+    "image": "images/stores/nike.jpg",
     "clothingType": "Activewear",
     "targetDemographic": ["Men", "Women"],
     "priceRange": "High",
@@ -33,7 +33,7 @@
   },
   {
     "name": "Adidas",
-    "image": "src/assets/images/stores/adidas.jpg",
+    "image": "images/stores/adidas.jpg",
     "clothingType": "Shoes",
     "targetDemographic": ["Women", "Men"],
     "priceRange": "High",
@@ -41,7 +41,7 @@
   },
   {
     "name": "Gucci",
-    "image": "src/assets/images/stores/gucci.jpg",
+    "image": "images/stores/gucci.jpg",
     "clothingType": "Dresses",
     "targetDemographic": ["Women"],
     "priceRange": "Luxury",
@@ -49,7 +49,7 @@
   },
   {
     "name": "Levi's",
-    "image": "src/assets/images/stores/levis.jpg",
+    "image": "images/stores/levis.jpg",
     "clothingType": "Jeans",
     "targetDemographic": ["Men", "Women"],
     "priceRange": "Mid",
@@ -57,7 +57,7 @@
   },
   {
     "name": "Gap",
-    "image": "src/assets/images/stores/gap.jpg",
+    "image": "images/stores/gap.jpg",
     "clothingType": "Casual",
     "targetDemographic": ["Kids", "Men", "Women"],
     "priceRange": "Low",
@@ -65,7 +65,7 @@
   },
   {
     "name": "Louis Vuitton",
-    "image": "src/assets/images/stores/louisvuitton.jpg",
+    "image": "images/stores/louisvuitton.jpg",
     "clothingType": "Accessories",
     "targetDemographic": ["Women", "Men"],
     "priceRange": "Luxury",
@@ -73,7 +73,7 @@
   },
   {
     "name": "Under Armour",
-    "image": "src/assets/images/stores/underarmour.jpg",
+    "image": "images/stores/underarmour.jpg",
     "clothingType": "Activewear",
     "targetDemographic": ["Men", "Women", "Kids"],
     "priceRange": "Mid",
@@ -81,7 +81,7 @@
   },
   {
     "name": "Amazon",
-    "image": "src/assets/images/stores/amazon.jpg",
+    "image": "images/stores/amazon.jpg",
     "clothingType": "Activewear",
     "targetDemographic": ["Men", "Women", "Kids"],
     "priceRange": "Mid",
@@ -89,7 +89,7 @@
   },
   {
     "name": "Prada",
-    "image": "src/assets/images/stores/prada.jpg",
+    "image": "images/stores/prada.jpg",
     "clothingType": "Accessories",
     "targetDemographic": ["Women", "Men"],
     "priceRange": "Luxury",
@@ -97,7 +97,7 @@
   },
   {
     "name": "Versace",
-    "image": "src/assets/images/stores/versace.jpg",
+    "image": "images/stores/versace.jpg",
     "clothingType": "Dresses",
     "targetDemographic": ["Women"],
     "priceRange": "Luxury",

--- a/src/components/FilterPanel/FilterPanel.tsx
+++ b/src/components/FilterPanel/FilterPanel.tsx
@@ -92,9 +92,14 @@ export const FilterPanel: React.FC<Props> = ({
               step={1}
               onValueChange={(val) => setPrice(val)}
             />
-            <div className="flex justify-between text-xs mt-2">
+            <div
+              className="grid mt-2 text-xs w-full"
+              style={{ gridTemplateColumns: `repeat(${priceLabels.length}, 1fr)` }}
+            >
               {priceLabels.map((l, i) => (
-                <span key={i}>{l}</span>
+                <span key={i} className="text-center">
+                  {l}
+                </span>
               ))}
             </div>
           </AccordionContent>

--- a/src/popup/StoresTab.tsx
+++ b/src/popup/StoresTab.tsx
@@ -44,17 +44,26 @@ function filterStores(
 export const StoresTab: React.FC<Props> = ({ initialStores }) => {
   const [stores, setStores] = useState<Store[]>([]);
   const [filtered, setFiltered] = useState<Store[]>([]);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     (async () => {
-      if (!initialStores) {
-        const mod = await import('./modules/storeService.js');
-        loadStores = mod.loadStores;
+      try {
+        if (!initialStores) {
+          const mod = await import('./modules/storeService.js');
+          loadStores = mod.loadStores;
+        }
+        const data = initialStores || (await loadStores());
+        const withRatings = data.map((s) => ({
+          ...s,
+          rating: Math.floor(Math.random() * 5) + 1,
+        }));
+        setStores(withRatings);
+        setFiltered(withRatings);
+      } catch (e) {
+        console.error(e);
+        setError(true);
       }
-      const data = initialStores || (await loadStores());
-      const withRatings = data.map((s) => ({ ...s, rating: Math.floor(Math.random() * 5) + 1 }));
-      setStores(withRatings);
-      setFiltered(withRatings);
     })();
   }, [initialStores]);
 
@@ -76,6 +85,10 @@ export const StoresTab: React.FC<Props> = ({ initialStores }) => {
   const demographics = Array.from(new Set(stores.flatMap((s) => s.targetDemographic)));
   const clothingTypes = Array.from(new Set(stores.map((s) => s.clothingType)));
 
+  if (error) {
+    return <div className="p-4">Could not load stores.</div>;
+  }
+
   return (
     <div className="p-4 grid gap-4 @lg:grid-cols-2">
       <FilterPanel
@@ -89,7 +102,7 @@ export const StoresTab: React.FC<Props> = ({ initialStores }) => {
         {filtered.map((store) => (
           <a key={store.name} href={store.url} className="text-center">
             <img
-              src={store.image}
+              src={chrome.runtime.getURL(store.image)}
               alt={store.name}
               loading="lazy"
               className="w-full rounded-xl mb-1"

--- a/src/popup/modules/storeService.js
+++ b/src/popup/modules/storeService.js
@@ -18,12 +18,8 @@ export async function loadStores(dataUrl = STORES_DATA_PATH) {
     cachedStores = await response.json();
     return cachedStores;
   } catch (error) {
-    console.error('Error loading stores:', error);
-    if (error instanceof TypeError) {
-      // Network or fetch failure, return an empty array so the UI can handle it
-      return [];
-    }
-    throw new Error(`Failed to load stores: ${error.message}`);
+    console.error("Error loading stores:", error);
+    throw error;
   }
 }
 

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,4 +1,7 @@
-export const STORES_DATA_PATH = 'src/assets/data/stores.json';
+// Path to the store metadata JSON bundled with the extension.  The build copies
+// everything from `src/assets` into the extension root, so the JSON lives under
+// `/data/stores.json` in the packaged extension.
+export const STORES_DATA_PATH = 'data/stores.json';
 
 // Base URL for the backend that processes "try on" requests.  Consumers can
 // override this via chrome.storage or by passing a different URL to the

--- a/test/auto/src/components/FilterPanel/__snapshots__/FilterPanel.test.tsx.snap
+++ b/test/auto/src/components/FilterPanel/__snapshots__/FilterPanel.test.tsx.snap
@@ -251,12 +251,17 @@ exports[`FilterPanel applies selected filters 1`] = `
               </span>
             </span>
             <div
-              class="flex justify-between text-xs mt-2"
+              class="grid mt-2 text-xs w-full"
+              style="grid-template-columns: repeat(2, 1fr);"
             >
-              <span>
+              <span
+                class="text-center"
+              >
                 Under $50
               </span>
-              <span>
+              <span
+                class="text-center"
+              >
                 $50-$100
               </span>
             </div>

--- a/test/storeService.test.mjs
+++ b/test/storeService.test.mjs
@@ -10,7 +10,8 @@ let fetchCount = 0;
 
 global.chrome = {
   runtime: {
-    getURL: (p) => pathToFileURL(join(__dirname, '..', p)).href,
+    // In tests, map extension URLs to files under `src/assets`.
+    getURL: (p) => pathToFileURL(join(__dirname, '..', 'src/assets', p)).href,
   },
 };
 
@@ -28,16 +29,16 @@ import { loadStores, clearStoreCache } from '../src/popup/modules/storeService.j
 async function runTests() {
   clearStoreCache();
   fetchCount = 0;
-  const stores1 = await loadStores('src/assets/data/stores.json');
+  const stores1 = await loadStores('data/stores.json');
   assert.ok(Array.isArray(stores1) && stores1.length > 0, 'loaded stores');
   assert.equal(fetchCount, 1, 'fetch called first time');
 
-  const stores2 = await loadStores('src/assets/data/stores.json');
+  const stores2 = await loadStores('data/stores.json');
   assert.equal(fetchCount, 1, 'cache used on second call');
   assert.strictEqual(stores1, stores2, 'same cached array');
 
   clearStoreCache();
-  const stores3 = await loadStores('src/assets/data/stores.json');
+  const stores3 = await loadStores('data/stores.json');
   assert.equal(fetchCount, 2, 'fetch called after clearing cache');
   assert.ok(Array.isArray(stores3), 'stores loaded again');
 

--- a/test/urlUtils.test.mjs
+++ b/test/urlUtils.test.mjs
@@ -9,7 +9,8 @@ const __dirname = dirname(__filename);
 // Mock chrome.runtime.getURL to return file URLs
 global.chrome = {
   runtime: {
-    getURL: (p) => pathToFileURL(join(__dirname, '..', p)).href,
+    // Map extension asset URLs to the source directory in tests.
+    getURL: (p) => pathToFileURL(join(__dirname, '..', 'src/assets', p)).href,
   },
 };
 


### PR DESCRIPTION
## Summary
- align price slider labels with a responsive CSS grid
- fetch store metadata from packaged assets and surface errors to users
- map store images via `chrome.runtime.getURL` and update tests accordingly

## Testing
- `npm test`
- `npm run lint` *(fails: Maximum call stack size exceeded in ESLint indent rule)*

------
https://chatgpt.com/codex/tasks/task_e_6893cb4ad20c832f868db29540a025a4