### PR TITLE
feat: add basic product and profile pages

### DIFF
--- a/frontend/src/data/products.ts
+++ b/frontend/src/data/products.ts
@@ -1,0 +1,35 @@
+export interface Product {
+  id: string;
+  name: string;
+  description: string;
+  price: number;
+  image: string;
+  store: string;
+}
+
+export const sampleProducts: Product[] = [
+  {
+    id: '1',
+    name: 'Smart Glasses',
+    description: 'AR-enabled smart glasses',
+    price: 299.99,
+    image: '/images/glasses.jpg',
+    store: 'Store A',
+  },
+  {
+    id: '2',
+    name: 'Wireless Headphones',
+    description: 'Noise-cancelling over-ear headphones',
+    price: 199.99,
+    image: '/images/headphones.jpg',
+    store: 'Store B',
+  },
+  {
+    id: '3',
+    name: 'Smartwatch',
+    description: 'Fitness-focused smartwatch',
+    price: 149.99,
+    image: '/images/smartwatch.jpg',
+    store: 'Store A',
+  },
+];

--- a/frontend/src/lib/wishlist.ts
+++ b/frontend/src/lib/wishlist.ts
@@ -1,0 +1,24 @@
+import { Product } from '../data/products';
+
+const STORAGE_KEY = 'wishlist';
+
+export function getWishlist(): Product[] {
+  if (typeof window === 'undefined') return [];
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? (JSON.parse(raw) as Product[]) : [];
+}
+
+export function addToWishlist(product: Product) {
+  if (typeof window === 'undefined') return;
+  const items = getWishlist();
+  if (!items.find((p) => p.id === product.id)) {
+    const updated = [...items, product];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  }
+}
+
+export function removeFromWishlist(id: string) {
+  if (typeof window === 'undefined') return;
+  const items = getWishlist().filter((p) => p.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}

--- a/frontend/src/pages/products/[id].tsx
+++ b/frontend/src/pages/products/[id].tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import { GetServerSideProps } from 'next';
+import { sampleProducts, Product } from '../../data/products';
+import { addToWishlist } from '../../lib/wishlist';
+
+interface Props {
+  product: Product | null;
+}
+
+export default function ProductDetail({ product }: Props) {
+  if (!product) return <div>Product not found</div>;
+
+  return (
+    <div>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+      <p>${product.price.toFixed(2)}</p>
+      <p>Available at: {product.store}</p>
+      <div>
+        <button onClick={() => addToWishlist(product)}>Add to Wishlist</button>
+        <button onClick={() => console.log('add to cart', product.id)}>Add to Cart</button>
+        <Link href={`/try-on?productId=${product.id}`}>Try On</Link>
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (context) => {
+  const { id } = context.params as { id: string };
+  const product = sampleProducts.find((p) => p.id === id) || null;
+  return { props: { product } };
+};

--- a/frontend/src/pages/products/index.tsx
+++ b/frontend/src/pages/products/index.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import Link from 'next/link';
+import { GetServerSideProps } from 'next';
+import { sampleProducts } from '../../data/products';
+
+export default function ProductsPage() {
+  const [search, setSearch] = useState('');
+  const [store, setStore] = useState('');
+
+  const stores = Array.from(new Set(sampleProducts.map((p) => p.store)));
+
+  const filtered = sampleProducts.filter((p) => {
+    const matchesSearch = p.name.toLowerCase().includes(search.toLowerCase());
+    const matchesStore = store ? p.store === store : true;
+    return matchesSearch && matchesStore;
+  });
+
+  return (
+    <div>
+      <h1>Products</h1>
+      <div>
+        <input
+          placeholder="Search products"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select value={store} onChange={(e) => setStore(e.target.value)}>
+          <option value="">All Stores</option>
+          {stores.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <ul>
+        {filtered.map((p) => (
+          <li key={p.id}>
+            <Link href={`/products/${p.id}`}>{p.name}</Link> - ${p.price.toFixed(2)} ({p.store})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return { props: {} };
+};

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import { GetServerSideProps } from 'next';
+
+interface ProfileData {
+  name: string;
+  email: string;
+}
+
+const STORAGE_KEY = 'profile';
+
+export default function Profile() {
+  const [profile, setProfile] = useState<ProfileData>({ name: '', email: '' });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) setProfile(JSON.parse(raw));
+  }, []);
+
+  const save = () => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+    alert('Profile saved');
+  };
+
+  return (
+    <div>
+      <h1>User Profile</h1>
+      <div>
+        <label>
+          Name
+          <input
+            value={profile.name}
+            onChange={(e) => setProfile({ ...profile, name: e.target.value })}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Email
+          <input
+            value={profile.email}
+            onChange={(e) => setProfile({ ...profile, email: e.target.value })}
+          />
+        </label>
+      </div>
+      <button onClick={save}>Save</button>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return { props: {} };
+};

--- a/frontend/src/pages/try-on.tsx
+++ b/frontend/src/pages/try-on.tsx
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/router';
+import { GetServerSideProps } from 'next';
+import { sampleProducts } from '../data/products';
+
+export default function TryOn() {
+  const router = useRouter();
+  const { productId } = router.query;
+  const product = sampleProducts.find((p) => p.id === productId);
+
+  return (
+    <div>
+      <h1>Virtual Try-On</h1>
+      {product ? (
+        <p>Preparing try-on experience for {product.name}...</p>
+      ) : (
+        <p>Select a product to try on.</p>
+      )}
+      <p>API integration coming soon.</p>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return { props: {} };
+};

--- a/frontend/src/pages/wishlist.tsx
+++ b/frontend/src/pages/wishlist.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { GetServerSideProps } from 'next';
+import { Product } from '../data/products';
+import { getWishlist, removeFromWishlist } from '../lib/wishlist';
+
+export default function Wishlist() {
+  const [items, setItems] = useState<Product[]>([]);
+
+  useEffect(() => {
+    setItems(getWishlist());
+  }, []);
+
+  const remove = (id: string) => {
+    removeFromWishlist(id);
+    setItems(getWishlist());
+  };
+
+  return (
+    <div>
+      <h1>Wishlist</h1>
+      {items.length === 0 ? (
+        <p>Your wishlist is empty.</p>
+      ) : (
+        <ul>
+          {items.map((p) => (
+            <li key={p.id}>
+              <Link href={`/products/${p.id}`}>{p.name}</Link>
+              <button onClick={() => remove(p.id)}>Remove</button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return { props: {} };
+};


### PR DESCRIPTION
## Summary
- add sample product data and wishlist helper
- build products list, detail, profile, wishlist, and try-on pages
- include server-side props placeholders for upcoming APIs

## Testing
- `npm --workspace frontend run build` *(fails: Minified React error #31)*

------
https://chatgpt.com/codex/tasks/task_e_6894e8421688832f82dbdeb6a5cd6b30