### PR TITLE
feat: add basic backend features

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/cors": "^2.8.17",
     "@types/node": "^20.12.12",
     "typescript": "5.9.2",
     "ts-node": "10.9.2"

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express';
+import crypto from 'crypto';
+import { users, sessions } from '../models/dataStore';
+import { User } from '../models/types';
+import { AuthRequest } from '../middleware/authMiddleware';
+
+export function signUp(req: Request, res: Response) {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ message: 'Username and password required' });
+  }
+  if (users.some(u => u.username === username)) {
+    return res.status(400).json({ message: 'User already exists' });
+  }
+  const user: User = {
+    id: crypto.randomUUID(),
+    username,
+    password,
+    settings: {}
+  };
+  users.push(user);
+  res.json({ id: user.id, username: user.username });
+}
+
+export function login(req: Request, res: Response) {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username && u.password === password);
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+  const token = crypto.randomUUID();
+  sessions.set(token, user.id);
+  res.json({ token });
+}
+
+export function logout(req: AuthRequest, res: Response) {
+  if (req.token) sessions.delete(req.token);
+  res.json({ message: 'Logged out' });
+}
+
+export function getProfile(req: AuthRequest, res: Response) {
+  const user = users.find(u => u.id === req.user?.id);
+  if (!user) return res.status(404).json({ message: 'User not found' });
+  res.json({ id: user.id, username: user.username, settings: user.settings });
+}
+
+export function updateProfile(req: AuthRequest, res: Response) {
+  const user = users.find(u => u.id === req.user?.id);
+  if (!user) return res.status(404).json({ message: 'User not found' });
+  const { settings } = req.body;
+  user.settings = { ...user.settings, ...settings };
+  res.json({ id: user.id, username: user.username, settings: user.settings });
+}

--- a/backend/src/controllers/productController.ts
+++ b/backend/src/controllers/productController.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from 'express';
+import crypto from 'crypto';
+import { products } from '../models/dataStore';
+import { Product } from '../models/types';
+import { AuthRequest } from '../middleware/authMiddleware';
+
+export function saveProduct(req: AuthRequest, res: Response) {
+  const { name, description, price } = req.body;
+  if (!name) return res.status(400).json({ message: 'Product name required' });
+  const product: Product = {
+    id: crypto.randomUUID(),
+    name,
+    description,
+    price,
+    ownerId: req.user?.id
+  };
+  products.push(product);
+  res.json(product);
+}
+
+export function listProducts(_req: Request, res: Response) {
+  res.json(products);
+}
+
+export function getProduct(req: Request, res: Response) {
+  const { id } = req.params;
+  const product = products.find(p => p.id === id);
+  if (!product) return res.status(404).json({ message: 'Product not found' });
+  res.json(product);
+}

--- a/backend/src/controllers/storeController.ts
+++ b/backend/src/controllers/storeController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import crypto from 'crypto';
+import { stores } from '../models/dataStore';
+import { Store } from '../models/types';
+
+export function listStores(_req: Request, res: Response) {
+  res.json(stores);
+}
+
+export function addStore(req: Request, res: Response) {
+  const { name } = req.body;
+  if (!name) return res.status(400).json({ message: 'Store name required' });
+  const store: Store = { id: crypto.randomUUID(), name };
+  stores.push(store);
+  res.json(store);
+}

--- a/backend/src/controllers/tryOnController.ts
+++ b/backend/src/controllers/tryOnController.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+
+export function tryOnPlaceholder(_req: Request, res: Response) {
+  res.json({ message: 'Virtual try-on integration coming soon' });
+}

--- a/backend/src/controllers/wishlistController.ts
+++ b/backend/src/controllers/wishlistController.ts
@@ -1,0 +1,35 @@
+import { Response } from 'express';
+import { products, wishlists } from '../models/dataStore';
+import { AuthRequest } from '../middleware/authMiddleware';
+
+export function addToWishlist(req: AuthRequest, res: Response) {
+  const { id } = req.params;
+  if (!products.some(p => p.id === id)) {
+    return res.status(404).json({ message: 'Product not found' });
+  }
+  const list = wishlists[req.user!.id] || [];
+  if (!list.includes(id)) list.push(id);
+  wishlists[req.user!.id] = list;
+  res.json({ wishlist: list });
+}
+
+export function removeFromWishlist(req: AuthRequest, res: Response) {
+  const { id } = req.params;
+  const list = wishlists[req.user!.id] || [];
+  wishlists[req.user!.id] = list.filter(pid => pid !== id);
+  res.json({ wishlist: wishlists[req.user!.id] });
+}
+
+export function getWishlist(req: AuthRequest, res: Response) {
+  const list = wishlists[req.user!.id] || [];
+  const items = list.map(id => products.find(p => p.id === id)).filter(Boolean);
+  res.json(items);
+}
+
+export function getAllWishlists(_req: AuthRequest, res: Response) {
+  const all = Object.entries(wishlists).map(([userId, ids]) => ({
+    userId,
+    products: ids.map(id => products.find(p => p.id === id)).filter(Boolean)
+  }));
+  res.json(all);
+}

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+import { sessions, users } from '../models/dataStore';
+
+export interface AuthRequest extends Request {
+  user?: { id: string; username: string };
+  token?: string;
+}
+
+export function authGuard(req: AuthRequest, res: Response, next: NextFunction) {
+  const header = req.headers['authorization'];
+  if (!header) return res.status(401).json({ message: 'No authorization header' });
+  const token = header.replace('Bearer ', '');
+  const userId = sessions.get(token);
+  if (!userId) return res.status(401).json({ message: 'Invalid token' });
+  const user = users.find(u => u.id === userId);
+  if (!user) return res.status(401).json({ message: 'User not found' });
+  req.user = { id: user.id, username: user.username };
+  req.token = token;
+  next();
+}

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  console.error(err);
+  res.status(500).json({ message: 'Internal server error' });
+}

--- a/backend/src/models/dataStore.ts
+++ b/backend/src/models/dataStore.ts
@@ -1,0 +1,7 @@
+import { User, Product, Store } from './types';
+
+export const users: User[] = [];
+export const products: Product[] = [];
+export const stores: Store[] = [];
+export const wishlists: Record<string, string[]> = {};
+export const sessions: Map<string, string> = new Map();

--- a/backend/src/models/types.ts
+++ b/backend/src/models/types.ts
@@ -1,0 +1,19 @@
+export interface User {
+  id: string;
+  username: string;
+  password: string;
+  settings?: Record<string, any>;
+}
+
+export interface Product {
+  id: string;
+  name: string;
+  description?: string;
+  price?: number;
+  ownerId?: string;
+}
+
+export interface Store {
+  id: string;
+  name: string;
+}

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { signUp, login, logout, getProfile, updateProfile } from '../controllers/authController';
+import { authGuard } from '../middleware/authMiddleware';
+
+const router = Router();
+
+router.post('/signup', signUp);
+router.post('/login', login);
+router.post('/logout', authGuard, logout);
+router.get('/profile', authGuard, getProfile);
+router.put('/profile', authGuard, updateProfile);
+
+export default router;

--- a/backend/src/routes/productRoutes.ts
+++ b/backend/src/routes/productRoutes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { saveProduct, listProducts, getProduct } from '../controllers/productController';
+import { authGuard } from '../middleware/authMiddleware';
+
+const router = Router();
+
+router.post('/', authGuard, saveProduct);
+router.get('/', listProducts);
+router.get('/:id', getProduct);
+
+export default router;

--- a/backend/src/routes/storeRoutes.ts
+++ b/backend/src/routes/storeRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listStores, addStore } from '../controllers/storeController';
+
+const router = Router();
+
+router.get('/', listStores);
+router.post('/', addStore);
+
+export default router;

--- a/backend/src/routes/tryOnRoutes.ts
+++ b/backend/src/routes/tryOnRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { tryOnPlaceholder } from '../controllers/tryOnController';
+
+const router = Router();
+
+router.get('/', tryOnPlaceholder);
+
+export default router;

--- a/backend/src/routes/wishlistRoutes.ts
+++ b/backend/src/routes/wishlistRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { addToWishlist, removeFromWishlist, getWishlist, getAllWishlists } from '../controllers/wishlistController';
+import { authGuard } from '../middleware/authMiddleware';
+
+const router = Router();
+
+router.get('/all', authGuard, getAllWishlists);
+router.get('/', authGuard, getWishlist);
+router.post('/:id', authGuard, addToWishlist);
+router.delete('/:id', authGuard, removeFromWishlist);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,12 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import authRoutes from './routes/authRoutes';
+import productRoutes from './routes/productRoutes';
+import wishlistRoutes from './routes/wishlistRoutes';
+import storeRoutes from './routes/storeRoutes';
+import tryOnRoutes from './routes/tryOnRoutes';
+import { errorHandler } from './middleware/errorHandler';
 
 dotenv.config();
 
@@ -11,9 +17,17 @@ const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
 app.use(cors({ origin: FRONTEND_URL }));
 app.use(express.json());
 
+app.use('/auth', authRoutes);
+app.use('/products', productRoutes);
+app.use('/wishlist', wishlistRoutes);
+app.use('/stores', storeRoutes);
+app.use('/try-on', tryOnRoutes);
+
 app.get('/', (_req, res) => {
   res.json({ message: 'API running' });
 });
+
+app.use(errorHandler);
 
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "sqlite3": "5.1.7"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.12.12",
         "ts-node": "10.9.2",
@@ -4392,6 +4393,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- add authentication, product, wishlist, store and try-on controllers
- wire up modular routes and middleware for auth and error handling
- configure in-memory data store and TypeScript types

## Testing
- `npm --workspace backend run build`


------
https://chatgpt.com/codex/tasks/task_e_6894e844e2dc832fb4582896aadc2034