### PR TITLE
feat: add top-level scripts for frontend and pin versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,19 @@
   "private": true,
   "workspaces": ["extension", "frontend", "backend"],
   "scripts": {
+    "build": "npm run build:frontend",
+    "dev": "npm run dev:frontend",
+    "start": "npm --workspace frontend run start",
     "build:extension": "npm --workspace extension run build",
     "build:frontend": "npm --workspace frontend run build",
     "build:backend": "npm --workspace backend run build",
     "serve:extension": "npm --workspace extension run dev",
     "dev:frontend": "npm --workspace frontend run dev",
     "start:backend": "npm --workspace backend run start"
+  },
+  "overrides": {
+    "next": "14.2.15",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- allow running frontend with root-level `npm run build`, `npm run dev`, and `npm start`
- pin Next.js/React versions via `overrides` to avoid accidental upgrades

## Testing
- `npm run build` *(fails: Failed to patch lockfile, please try uninstalling and reinstalling next in this workspace)*
- `npm run dev` *(fails: Failed to patch lockfile, please try uninstalling and reinstalling next in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_6894f3581fe4832f926f62d68bc321dd